### PR TITLE
Add typeDefs and resolvers for tutorials

### DIFF
--- a/server/models/Tutorial.js
+++ b/server/models/Tutorial.js
@@ -22,7 +22,7 @@ const tutorialSchema = new Schema(
                 ref: 'Category',
             },
         ],
-        teacherId: [
+        teacher: [
             {
                 type: Schema.Types.ObjectId,
                 ref: 'User',

--- a/server/schemas/tutorialDefs.js
+++ b/server/schemas/tutorialDefs.js
@@ -2,7 +2,6 @@ const { gql } = require('apollo-server-express');
 
 const { Tutorial } = require('../models');
 
-// TODO: Complete Tutorial typeDefs
 const tutorialTypeDefs = gql`
   type Tutorial {
     _id: ID!
@@ -10,25 +9,77 @@ const tutorialTypeDefs = gql`
     overview: String
     thumbnail: String
     categories: [Category]
-    teacherId: [User]
+    teacher: [User]
     lessons: [Lesson]
     reviews: [Review]
+    totalDuration: Int
   }
 
   type Query {
     tutorials: [Tutorial]
+    tutorial(_id: ID!): Tutorial
+  }
+
+  type Mutation {
+    addTutorial(title: String!, overview: String!, thumbnail: String!, categories: [ID]!, teacher: [ID]!): Tutorial
+    updateTutorial(_id: ID!, title: String, overview: String, thumbnail: String, categories: [ID]): Tutorial
+    deleteTutorial(_id: ID!): Tutorial
   }
 `;
 
-// TODO: Complete Resolvers for Tutorial typeDefs
 const tutorialResolvers = {
   Query: {
+    // Get all tutorials
     tutorials: async () => {
       return await Tutorial.find({})
         .populate('categories')
-        .populate('teacherId')
+        .populate('teacher')
         .populate('lessons')
         .populate('reviews');
+    },
+
+    // Get a single tutorial by ID
+    tutorial: async (parent, { _id }) => {
+      return await Tutorial.findById(_id)
+        .populate('categories')
+        .populate('teacher')
+        .populate('lessons')
+        .populate('reviews');
+    },
+  },
+  Mutation: {
+    // Add a tutorial
+    addTutorial: async (parent, { title, overview, thumbnail, categories, teacher }) => {
+      return await Tutorial.create({ title, overview, thumbnail, categories, teacher });
+    },
+
+    // Update a tutorial's title, overview, thumbnail, and/or categories
+    updateTutorial: async (parent, { _id, title, overview, thumbnail, categories }) => {
+      // Create an updates object only containing the updated fields
+      const updates = {};
+      if (title) {
+        updates.title = title;
+      }
+      if (overview) {
+        updates.overview = overview;
+      }
+      if (thumbnail) {
+        updates.thumbnail = thumbnail;
+      }
+      if (categories) {
+        updates.categories = categories;
+      }
+
+      return await Tutorial.findByIdAndUpdate(
+        _id,
+        { $set: updates },
+        { new: true },
+      );
+    },
+
+    // Delete a tutorial
+    deleteTutorial: async (parent, { _id }) => {
+      return await Tutorial.findByIdAndDelete(_id);
     }
   }
 };

--- a/server/seeds/seed.js
+++ b/server/seeds/seed.js
@@ -60,7 +60,7 @@ db.once('open', async () => {
         tutorial.reviews.push(getRandomId(reviewIds));
       }
 
-      tutorial.teacherId = getRandomId(userIds);
+      tutorial.teacher = getRandomId(userIds);
     });
 
     // Add tutorials to the db


### PR DESCRIPTION
Add typeDefs and resolvers for tutorials, including:
- Getting a single tutorial by ID
- Adding a tutorial
    - Note that only title, overview, thumbnail, categories, and teacher are required
    - Lessons and reviews to be attached separately through their own resolvers upon creation of those items
- Updating a tutorial by ID
    - Note that only the title, overview, thumbnail, and categories can be updated
    - Teacher shouldn't change, and lessons and reviews are updated separately through their own resolvers.
- Deleting a tutorial by ID

To test:
- `npm run seed` in the root project folder
    - IMPORTANT: Do this before the first test even if you have seeded already. This PR changes the `teacherId` property name to `teacher`.
- `npm start`
- Go to `/graphql` in the browser to test the 1 new query and 3 new mutations
    - Note: When testing the mutations, some of the returned data may come up as `null`. This is because of the way the data is returned and not because the data is null in the db. To confirm the db has the data, run the query for all tutorials or a single tutorial.