### PR TITLE
Add typeDefs and resolvers for reviews

### DIFF
--- a/server/schemas/reviewDefs.js
+++ b/server/schemas/reviewDefs.js
@@ -1,25 +1,73 @@
 const { gql } = require('apollo-server-express');
 
-const { Review } = require('../models');
+const { Review, Tutorial } = require('../models');
 
-// TODO: Complete Review typeDefs
 const reviewTypeDefs = gql`
   type Review {
     _id: ID!
-    rating: Float
+    rating: Int
     comment: String
   }
 
   type Query {
     reviews: [Review]
+    review(_id: ID!): Review
+  }
+
+  type Mutation {
+    addReview(tutorialId: String!, rating: Int, comment: String): Review
+    updateReview(_id: ID!, rating: Int, comment: String): Review
+    deleteReview(_id: ID!): Review
   }
 `;
 
-// TODO: Complete Resolvers for Review typeDefs
 const reviewResolvers = {
   Query: {
+    // Get all reviews
     reviews: async () => {
       return await Review.find({});
+    },
+
+    // Get a single review by ID
+    review: async (parent, { _id }) => {
+      return await Review.findById(_id);
+    }
+  },
+  Mutation: {
+    // Add a review and attach it to its tutorial
+    addReview: async (parent, { tutorialId, rating, comment }) => {
+      const reviewResult = await Review.create({ rating, comment});
+      
+      await Tutorial.findByIdAndUpdate(
+        tutorialId,
+        { $push: { reviews: reviewResult._id } },
+        { new: true }
+      );
+
+      return reviewResult;
+    },
+
+    // Update a review's rating and/or comment
+    updateReview: async (parent, { _id, rating, comment }) => {
+      // Create an updates object only containing the updated fields
+      const updates = {};
+      if (rating) {
+        updates.rating = rating;
+      }
+      if (comment) {
+        updates.comment = comment;
+      }
+
+      return await Review.findByIdAndUpdate(
+        _id,
+        { $set: updates },
+        { new: true },
+      );
+    },
+
+    // Delete a review
+    deleteReview: async (parent, { _id, tutorialId }) => {
+      return await Review.findByIdAndDelete(_id);
     }
   }
 };


### PR DESCRIPTION
Add typeDefs and resolvers for reviews, including:

- Getting a single review by ID
- Adding a review (includes adding the review to the db as well as attaching it to the tutorial)
- Updating a review by ID
- Deleting a review by ID

To test:
- `npm run seed` in the root project folder (anyone who hasn't seeded since the tutorial typeDefs were added should do this--I changed one of the property names in that PR)
- `npm start`
- Go to `/graphql` in the browser to test the 1 new query and 3 new mutations
