### PR TITLE
Update seeds to use .create instead of .insertMany

### DIFF
--- a/server/seeds/seed.js
+++ b/server/seeds/seed.js
@@ -28,20 +28,20 @@ db.once('open', async () => {
     await User.deleteMany({});
 
     // Add categories to db and get the resulting IDs
-    const categoryResult = await Category.collection.insertMany(categorySeeds);
-    const categoryIds = Object.values(categoryResult.insertedIds);
+    const categoryResult = await Category.create(categorySeeds);
+    const categoryIds = categoryResult.map(category => category._id);
 
     // Add lessons to db and get the resulting IDs
-    const lessonResult = await Lesson.collection.insertMany(lessonSeeds);
-    const lessonIds = Object.values(lessonResult.insertedIds);
+    const lessonResult = await Lesson.create(lessonSeeds);
+    const lessonIds = lessonResult.map(lesson => lesson._id);
     
     // Add reviews to db and get the resulting IDs
-    const reviewResult = await Review.collection.insertMany(reviewSeeds);
-    const reviewIds = Object.values(reviewResult.insertedIds);
+    const reviewResult = await Review.create(reviewSeeds);
+    const reviewIds = reviewResult.map(review => review._id);
 
     // Add users to db and get the resulting IDs
-    const userResult = await User.collection.insertMany(userSeeds);
-    const userIds = Object.values(userResult.insertedIds);
+    const userResult = await User.create(userSeeds);
+    const userIds = userResult.map(user => user._id);
 
     // For each tutorial, randomly set 2 category IDs, 4 lesson IDs, 2 review IDs, & a teacher ID
     tutorialSeeds.map((tutorial) => {


### PR DESCRIPTION
In order to fix the issue of the passwords not hashing when the users were seeded, the `.insertMany` functions need to be changed to `.create`. This also requires updating the code to grab the IDs from the result of the create.

To test, run `npm run seed` and view the database in MongoDB Compass or run `npm start` and run some queries at `/graphql` in the browser.