### PR TITLE
Tutorials by cat

### DIFF
--- a/server/schemas/tutorialDefs.js
+++ b/server/schemas/tutorialDefs.js
@@ -22,8 +22,20 @@ const tutorialTypeDefs = gql`
   }
 
   type Mutation {
-    addTutorial(title: String!, overview: String!, thumbnail: String!, categories: [ID]!, teacher: [ID]!): Tutorial
-    updateTutorial(_id: ID!, title: String, overview: String, thumbnail: String, categories: [ID]): Tutorial
+    addTutorial(
+      title: String!
+      overview: String!
+      thumbnail: String!
+      categories: [ID]!
+      teacher: [ID]!
+    ): Tutorial
+    updateTutorial(
+      _id: ID!
+      title: String
+      overview: String
+      thumbnail: String
+      categories: [ID]
+    ): Tutorial
     deleteTutorial(_id: ID!): Tutorial
   }
 `;
@@ -34,10 +46,10 @@ const tutorialResolvers = {
     tutorials: async function () {
       try {
         return await Tutorial.find({})
-        .populate('categories')
-        .populate('teacher')
-        .populate('lessons')
-        .populate('reviews');
+          .populate('categories')
+          .populate('teacher')
+          .populate('lessons')
+          .populate('reviews');
       } catch (error) {
         throw new Error(`Failed to fetch tutorials: ${error.message}`);
       }
@@ -47,17 +59,17 @@ const tutorialResolvers = {
     tutorial: async function (parent, { _id }) {
       try {
         return await Tutorial.findById(_id)
-        .populate('categories')
-        .populate('teacher')
-        .populate('lessons')
-        .populate('reviews');
+          .populate('categories')
+          .populate('teacher')
+          .populate('lessons')
+          .populate('reviews');
       } catch (error) {
         throw new Error(`Failed to fetch single tutorial: ${error.message}`);
       }
     },
 
     // Get all tutorials in a single category by category ID
-    tutorialsByCategory: async function(parent, { categoryId }) {
+    tutorialsByCategory: async function (parent, { categoryId }) {
       try {
         return await Tutorial.find({ categories: categoryId })
           .populate('categories')
@@ -65,23 +77,37 @@ const tutorialResolvers = {
           .populate('lessons')
           .populate('reviews');
       } catch (error) {
-        throw new Error(`Failed to fetch tutorials by category: ${error.message}`);
+        throw new Error(
+          `Failed to fetch tutorials by category: ${error.message}`
+        );
       }
     },
   },
 
   Mutation: {
     // Add a tutorial
-    addTutorial: async function (parent, { title, overview, thumbnail, categories, teacher }) {
+    addTutorial: async function (
+      parent,
+      { title, overview, thumbnail, categories, teacher }
+    ) {
       try {
-        return await Tutorial.create({ title, overview, thumbnail, categories, teacher });
+        return await Tutorial.create({
+          title,
+          overview,
+          thumbnail,
+          categories,
+          teacher,
+        });
       } catch (error) {
         throw new Error(`Failed to add tutorial: ${error.message}`);
       }
     },
 
     // Update a tutorial's title, overview, thumbnail, and/or categories
-    updateTutorial: async function(parent, { _id, title, overview, thumbnail, categories }) {
+    updateTutorial: async function (
+      parent,
+      { _id, title, overview, thumbnail, categories }
+    ) {
       try {
         // Create an updates object only containing the updated fields
         const updates = {};
@@ -101,7 +127,7 @@ const tutorialResolvers = {
         return await Tutorial.findByIdAndUpdate(
           _id,
           { $set: updates },
-          { new: true },
+          { new: true }
         );
       } catch (error) {
         throw new Error(`Failed to update tutorial: ${error.message}`);

--- a/server/schemas/tutorialDefs.js
+++ b/server/schemas/tutorialDefs.js
@@ -31,7 +31,7 @@ const tutorialTypeDefs = gql`
 const tutorialResolvers = {
   Query: {
     // Get all tutorials
-    tutorials: async () => {
+    tutorials: async function () {
       return await Tutorial.find({})
         .populate('categories')
         .populate('teacher')
@@ -40,7 +40,7 @@ const tutorialResolvers = {
     },
 
     // Get a single tutorial by ID
-    tutorial: async (parent, { _id }) => {
+    tutorial: async function (parent, { _id }) {
       return await Tutorial.findById(_id)
         .populate('categories')
         .populate('teacher')
@@ -57,15 +57,15 @@ const tutorialResolvers = {
       }
     },
   },
-  
+
   Mutation: {
     // Add a tutorial
-    addTutorial: async (parent, { title, overview, thumbnail, categories, teacher }) => {
+    addTutorial: async function (parent, { title, overview, thumbnail, categories, teacher }) {
       return await Tutorial.create({ title, overview, thumbnail, categories, teacher });
     },
 
     // Update a tutorial's title, overview, thumbnail, and/or categories
-    updateTutorial: async (parent, { _id, title, overview, thumbnail, categories }) => {
+    updateTutorial: async function (parent, { _id, title, overview, thumbnail, categories }) {
       // Create an updates object only containing the updated fields
       const updates = {};
       if (title) {
@@ -84,15 +84,15 @@ const tutorialResolvers = {
       return await Tutorial.findByIdAndUpdate(
         _id,
         { $set: updates },
-        { new: true },
+        { new: true }
       );
     },
 
     // Delete a tutorial
-    deleteTutorial: async (parent, { _id }) => {
+    deleteTutorial: async function (parent, { _id }) {
       return await Tutorial.findByIdAndDelete(_id);
-    }
-  }
+    },
+  },
 };
 
 module.exports = { tutorialTypeDefs, tutorialResolvers };

--- a/server/schemas/tutorialDefs.js
+++ b/server/schemas/tutorialDefs.js
@@ -3,13 +3,18 @@ const { gql } = require('apollo-server-express');
 const { Tutorial, Category } = require('../models');
 
 const tutorialTypeDefs = gql`
+  type Teacher {
+    _id: ID!
+    username: String
+  }
+
   type Tutorial {
     _id: ID!
     title: String
     overview: String
     thumbnail: String
     categories: [Category]
-    teacher: [User]
+    teacher: [Teacher]
     lessons: [Lesson]
     reviews: [Review]
     totalDuration: Int

--- a/server/schemas/tutorialDefs.js
+++ b/server/schemas/tutorialDefs.js
@@ -31,27 +31,39 @@ const tutorialTypeDefs = gql`
 const tutorialResolvers = {
   Query: {
     // Get all tutorials
-    tutorials: async function() {
-      return await Tutorial.find({})
+    tutorials: async function () {
+      try {
+        return await Tutorial.find({})
         .populate('categories')
         .populate('teacher')
         .populate('lessons')
         .populate('reviews');
+      } catch (error) {
+        throw new Error(`Failed to fetch tutorials: ${error.message}`);
+      }
     },
 
     // Get a single tutorial by ID
-    tutorial: async function(parent, { _id }) {
-      return await Tutorial.findById(_id)
+    tutorial: async function (parent, { _id }) {
+      try {
+        return await Tutorial.findById(_id)
         .populate('categories')
         .populate('teacher')
         .populate('lessons')
         .populate('reviews');
+      } catch (error) {
+        throw new Error(`Failed to fetch single tutorial: ${error.message}`);
+      }
     },
 
     // Get all tutorials in a single category by category ID
     tutorialsByCategory: async function(parent, { categoryId }) {
       try {
-        return await Tutorial.find({ categories: categoryId });
+        return await Tutorial.find({ categories: categoryId })
+          .populate('categories')
+          .populate('teacher')
+          .populate('lessons')
+          .populate('reviews');
       } catch (error) {
         throw new Error(`Failed to fetch tutorials by category: ${error.message}`);
       }
@@ -60,37 +72,49 @@ const tutorialResolvers = {
 
   Mutation: {
     // Add a tutorial
-    addTutorial: async function(parent, { title, overview, thumbnail, categories, teacher }) {
-      return await Tutorial.create({ title, overview, thumbnail, categories, teacher });
+    addTutorial: async function (parent, { title, overview, thumbnail, categories, teacher }) {
+      try {
+        return await Tutorial.create({ title, overview, thumbnail, categories, teacher });
+      } catch (error) {
+        throw new Error(`Failed to add tutorial: ${error.message}`);
+      }
     },
 
     // Update a tutorial's title, overview, thumbnail, and/or categories
     updateTutorial: async function(parent, { _id, title, overview, thumbnail, categories }) {
-      // Create an updates object only containing the updated fields
-      const updates = {};
-      if (title) {
-        updates.title = title;
-      }
-      if (overview) {
-        updates.overview = overview;
-      }
-      if (thumbnail) {
-        updates.thumbnail = thumbnail;
-      }
-      if (categories) {
-        updates.categories = categories;
-      }
+      try {
+        // Create an updates object only containing the updated fields
+        const updates = {};
+        if (title) {
+          updates.title = title;
+        }
+        if (overview) {
+          updates.overview = overview;
+        }
+        if (thumbnail) {
+          updates.thumbnail = thumbnail;
+        }
+        if (categories) {
+          updates.categories = categories;
+        }
 
-      return await Tutorial.findByIdAndUpdate(
-        _id,
-        { $set: updates },
-        { new: true },
-      );
+        return await Tutorial.findByIdAndUpdate(
+          _id,
+          { $set: updates },
+          { new: true },
+        );
+      } catch (error) {
+        throw new Error(`Failed to update tutorial: ${error.message}`);
+      }
     },
 
     // Delete a tutorial
-    deleteTutorial: async function(parent, { _id }) {
-      return await Tutorial.findByIdAndDelete(_id);
+    deleteTutorial: async function (parent, { _id }) {
+      try {
+        return await Tutorial.findByIdAndDelete(_id);
+      } catch (error) {
+        throw new Error(`Failed to delete tutorial: ${error.message}`);
+      }
     },
   },
 };

--- a/server/schemas/tutorialDefs.js
+++ b/server/schemas/tutorialDefs.js
@@ -84,7 +84,7 @@ const tutorialResolvers = {
       return await Tutorial.findByIdAndUpdate(
         _id,
         { $set: updates },
-        { new: true }
+        { new: true },
       );
     },
 

--- a/server/schemas/tutorialDefs.js
+++ b/server/schemas/tutorialDefs.js
@@ -31,7 +31,7 @@ const tutorialTypeDefs = gql`
 const tutorialResolvers = {
   Query: {
     // Get all tutorials
-    tutorials: async function () {
+    tutorials: async function() {
       return await Tutorial.find({})
         .populate('categories')
         .populate('teacher')
@@ -40,7 +40,7 @@ const tutorialResolvers = {
     },
 
     // Get a single tutorial by ID
-    tutorial: async function (parent, { _id }) {
+    tutorial: async function(parent, { _id }) {
       return await Tutorial.findById(_id)
         .populate('categories')
         .populate('teacher')
@@ -49,7 +49,7 @@ const tutorialResolvers = {
     },
 
     // Get all tutorials in a single category by category ID
-    tutorialsByCategory: async function (parent, { categoryId }) {
+    tutorialsByCategory: async function(parent, { categoryId }) {
       try {
         return await Tutorial.find({ categories: categoryId });
       } catch (error) {
@@ -60,12 +60,12 @@ const tutorialResolvers = {
 
   Mutation: {
     // Add a tutorial
-    addTutorial: async function (parent, { title, overview, thumbnail, categories, teacher }) {
+    addTutorial: async function(parent, { title, overview, thumbnail, categories, teacher }) {
       return await Tutorial.create({ title, overview, thumbnail, categories, teacher });
     },
 
     // Update a tutorial's title, overview, thumbnail, and/or categories
-    updateTutorial: async function (parent, { _id, title, overview, thumbnail, categories }) {
+    updateTutorial: async function(parent, { _id, title, overview, thumbnail, categories }) {
       // Create an updates object only containing the updated fields
       const updates = {};
       if (title) {
@@ -89,7 +89,7 @@ const tutorialResolvers = {
     },
 
     // Delete a tutorial
-    deleteTutorial: async function (parent, { _id }) {
+    deleteTutorial: async function(parent, { _id }) {
       return await Tutorial.findByIdAndDelete(_id);
     },
   },

--- a/server/schemas/tutorialDefs.js
+++ b/server/schemas/tutorialDefs.js
@@ -1,6 +1,6 @@
 const { gql } = require('apollo-server-express');
 
-const { Tutorial } = require('../models');
+const { Tutorial, Category } = require('../models');
 
 const tutorialTypeDefs = gql`
   type Tutorial {
@@ -18,6 +18,7 @@ const tutorialTypeDefs = gql`
   type Query {
     tutorials: [Tutorial]
     tutorial(_id: ID!): Tutorial
+    tutorialsByCategory(categoryId: ID!): [Tutorial]
   }
 
   type Mutation {
@@ -46,7 +47,17 @@ const tutorialResolvers = {
         .populate('lessons')
         .populate('reviews');
     },
+
+    // Get all tutorials in a single category by category ID
+    tutorialsByCategory: async function (parent, { categoryId }) {
+      try {
+        return await Tutorial.find({ categories: categoryId });
+      } catch (error) {
+        throw new Error(`Failed to fetch tutorials by category: ${error.message}`);
+      }
+    },
   },
+  
   Mutation: {
     // Add a tutorial
     addTutorial: async (parent, { title, overview, thumbnail, categories, teacher }) => {


### PR DESCRIPTION
closes #72 

Add query to get all tutorials that belong to a specific category.
Update tutorial resolvers to use function declarations instead of arrow functions.

To test, `npm run seed` and then `npm start`. Go to `localhost:3001/graphql` in the browser and test the `tutorialsByCategory` query (first query categories to get a category ID).