### PR TITLE
Update seeds to add tutorials to users

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -24,6 +24,12 @@ const userSchema = new Schema({
     required: true,
     minlength: 8,
   },
+  tutorials: [
+    {
+      type: Schema.Types.ObjectId,
+      ref: 'Tutorial',
+    },
+  ],
 });
 
 // set up pre-save middleware to create password

--- a/server/seeds/seed.js
+++ b/server/seeds/seed.js
@@ -16,7 +16,7 @@ const userSeeds = require('./userSeeds.js');
 
 function getRandomId(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
-};
+}
 
 db.once('open', async () => {
   try {
@@ -29,34 +29,34 @@ db.once('open', async () => {
 
     // Add categories to db and get the resulting IDs
     const categoryResult = await Category.create(categorySeeds);
-    const categoryIds = categoryResult.map(category => category._id);
+    const categoryIds = categoryResult.map((category) => category._id);
 
     // Add lessons to db and get the resulting IDs
     const lessonResult = await Lesson.create(lessonSeeds);
-    const lessonIds = lessonResult.map(lesson => lesson._id);
-    
+    const lessonIds = lessonResult.map((lesson) => lesson._id);
+
     // Add reviews to db and get the resulting IDs
     const reviewResult = await Review.create(reviewSeeds);
-    const reviewIds = reviewResult.map(review => review._id);
+    const reviewIds = reviewResult.map((review) => review._id);
 
     // Add users to db and get the resulting IDs
     const userResult = await User.create(userSeeds);
-    const userIds = userResult.map(user => user._id);
+    const userIds = userResult.map((user) => user._id);
 
     // For each tutorial, randomly set 2 category IDs, 4 lesson IDs, 2 review IDs, & a teacher ID
     tutorialSeeds.map((tutorial) => {
       tutorial.categories = [];
-      for (let i = 0; i < 2; i ++) {
+      for (let i = 0; i < 2; i++) {
         tutorial.categories.push(getRandomId(categoryIds));
       }
 
       tutorial.lessons = [];
-      for (let i = 0; i < 4; i ++) {
+      for (let i = 0; i < 4; i++) {
         tutorial.lessons.push(getRandomId(lessonIds));
       }
 
       tutorial.reviews = [];
-      for (let i = 0; i < 2; i ++) {
+      for (let i = 0; i < 2; i++) {
         tutorial.reviews.push(getRandomId(reviewIds));
       }
 
@@ -64,7 +64,28 @@ db.once('open', async () => {
     });
 
     // Add tutorials to the db
-    await Tutorial.collection.insertMany(tutorialSeeds);
+    const tutorialResult = await Tutorial.create(tutorialSeeds);
+    const tutorialIds = tutorialResult.map((tutorial) => tutorial._id);
+
+    // Add enrolled tutorials to users
+    const users = await User.find({});
+
+    for (const user of users) {
+      const userTutorials = [];
+      for (let i = 0; i < 2; i++) {
+        userTutorials.push(getRandomId(tutorialIds));
+      }
+
+      await User.updateOne(
+        { _id: user._id },
+        {
+          $addToSet: { tutorials: userTutorials },
+        },
+        {
+          new: true,
+        }
+      );
+    }
   } catch (error) {
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
Update seeds to include adding tutorials to users.
Includes some minor tweaks from running Prettier.

To test: `npm run seed` and then go into MongoDB Compass or go to `localhost:3001/graphql` and query users  to verify that users have an array of two random tutorial IDs.