### PR TITLE
Fix review defs

### DIFF
--- a/server/schemas/reviewDefs.js
+++ b/server/schemas/reviewDefs.js
@@ -24,7 +24,7 @@ const reviewTypeDefs = gql`
 const reviewResolvers = {
   Query: {
     // Get all reviews
-    reviews: async function() {
+    reviews: async function () {
       try {
         return await Review.find({});
       } catch (error) {
@@ -33,7 +33,7 @@ const reviewResolvers = {
     },
 
     // Get a single review by ID
-    review: async function(parent, { _id }) {
+    review: async function (parent, { _id }) {
       try {
         return await Review.findById(_id);
       } catch (error) {
@@ -41,13 +41,13 @@ const reviewResolvers = {
       }
     },
   },
-  
+
   Mutation: {
     // Add a review and attach it to its tutorial
-    addReview: async function(parent, { tutorialId, rating, comment }) {
+    addReview: async function (parent, { tutorialId, rating, comment }) {
       try {
-        const reviewResult = await Review.create({ rating, comment});
-      
+        const reviewResult = await Review.create({ rating, comment });
+
         await Tutorial.findByIdAndUpdate(
           tutorialId,
           { $push: { reviews: reviewResult._id } },
@@ -61,7 +61,7 @@ const reviewResolvers = {
     },
 
     // Update a review's rating and/or comment
-    updateReview: async function(parent, { _id, rating, comment }) {
+    updateReview: async function (parent, { _id, rating, comment }) {
       try {
         // Create an updates object only containing the updated fields
         const updates = {};
@@ -75,7 +75,7 @@ const reviewResolvers = {
         return await Review.findByIdAndUpdate(
           _id,
           { $set: updates },
-          { new: true },
+          { new: true }
         );
       } catch (error) {
         throw new Error(`Failed to update review: ${error.message}`);
@@ -83,7 +83,7 @@ const reviewResolvers = {
     },
 
     // Delete a review
-    deleteReview: async function(parent, { _id, tutorialId }) {
+    deleteReview: async function (parent, { _id, tutorialId }) {
       try {
         return await Review.findByIdAndDelete(_id);
       } catch (error) {

--- a/server/schemas/reviewDefs.js
+++ b/server/schemas/reviewDefs.js
@@ -24,18 +24,19 @@ const reviewTypeDefs = gql`
 const reviewResolvers = {
   Query: {
     // Get all reviews
-    reviews: async () => {
+    reviews: async function() {
       return await Review.find({});
     },
 
     // Get a single review by ID
-    review: async (parent, { _id }) => {
+    review: async function(parent, { _id }) {
       return await Review.findById(_id);
     }
   },
+  
   Mutation: {
     // Add a review and attach it to its tutorial
-    addReview: async (parent, { tutorialId, rating, comment }) => {
+    addReview: async function(parent, { tutorialId, rating, comment }) {
       const reviewResult = await Review.create({ rating, comment});
       
       await Tutorial.findByIdAndUpdate(
@@ -48,7 +49,7 @@ const reviewResolvers = {
     },
 
     // Update a review's rating and/or comment
-    updateReview: async (parent, { _id, rating, comment }) => {
+    updateReview: async function(parent, { _id, rating, comment }) {
       // Create an updates object only containing the updated fields
       const updates = {};
       if (rating) {
@@ -66,7 +67,7 @@ const reviewResolvers = {
     },
 
     // Delete a review
-    deleteReview: async (parent, { _id, tutorialId }) => {
+    deleteReview: async function(parent, { _id, tutorialId }) {
       return await Review.findByIdAndDelete(_id);
     }
   }

--- a/server/schemas/reviewDefs.js
+++ b/server/schemas/reviewDefs.js
@@ -25,52 +25,72 @@ const reviewResolvers = {
   Query: {
     // Get all reviews
     reviews: async function() {
-      return await Review.find({});
+      try {
+        return await Review.find({});
+      } catch (error) {
+        throw new Error(`Failed to get all reviews: ${error.message}`);
+      }
     },
 
     // Get a single review by ID
     review: async function(parent, { _id }) {
-      return await Review.findById(_id);
-    }
+      try {
+        return await Review.findById(_id);
+      } catch (error) {
+        throw new Error(`Failed to get single review: ${error.message}`);
+      }
+    },
   },
   
   Mutation: {
     // Add a review and attach it to its tutorial
     addReview: async function(parent, { tutorialId, rating, comment }) {
-      const reviewResult = await Review.create({ rating, comment});
+      try {
+        const reviewResult = await Review.create({ rating, comment});
       
-      await Tutorial.findByIdAndUpdate(
-        tutorialId,
-        { $push: { reviews: reviewResult._id } },
-        { new: true }
-      );
+        await Tutorial.findByIdAndUpdate(
+          tutorialId,
+          { $push: { reviews: reviewResult._id } },
+          { new: true }
+        );
 
-      return reviewResult;
+        return reviewResult;
+      } catch (error) {
+        throw new Error(`Failed to add review: ${error.message}`);
+      }
     },
 
     // Update a review's rating and/or comment
     updateReview: async function(parent, { _id, rating, comment }) {
-      // Create an updates object only containing the updated fields
-      const updates = {};
-      if (rating) {
-        updates.rating = rating;
-      }
-      if (comment) {
-        updates.comment = comment;
-      }
+      try {
+        // Create an updates object only containing the updated fields
+        const updates = {};
+        if (rating) {
+          updates.rating = rating;
+        }
+        if (comment) {
+          updates.comment = comment;
+        }
 
-      return await Review.findByIdAndUpdate(
-        _id,
-        { $set: updates },
-        { new: true },
-      );
+        return await Review.findByIdAndUpdate(
+          _id,
+          { $set: updates },
+          { new: true },
+        );
+      } catch (error) {
+        throw new Error(`Failed to update review: ${error.message}`);
+      }
     },
 
     // Delete a review
     deleteReview: async function(parent, { _id, tutorialId }) {
-      return await Review.findByIdAndDelete(_id);
-    }
-  }
+      try {
+        return await Review.findByIdAndDelete(_id);
+      } catch (error) {
+        throw new Error(`Failed to delete review: ${error.message}`);
+      }
+    },
+  },
 };
 
 module.exports = { reviewTypeDefs, reviewResolvers };


### PR DESCRIPTION
Update `reviewDefs.js` to meet our syntax conventions:
- Function declarations instead of arrow functions when not callback functions
- Use `try... catch` blocks for resolvers

To test: `npm run seed` and then `npm start`. Go to `localhost:3001/graphql` and run the queries and mutations to confirm they still work as expected.