### PR TITLE
Add tutorial pg

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,9 +10,10 @@ import {
 } from '@apollo/client';
 import './style/App.css';
 import { 
-  SignUp, 
-  SignIn, 
+  AddTutorial,
   Home,
+  SignIn, 
+  SignUp, 
 } from './pages';
 import { Footer, Navbar } from './components';
 
@@ -39,6 +40,10 @@ function App() {
             <Route
               path='/signin'
               element={<SignIn />}
+            ></Route>
+            <Route
+              path='/tutorials/new'
+              element={<AddTutorial />}
             ></Route>
           </Routes>
         </Router>

--- a/client/src/pages/AddTutorial.js
+++ b/client/src/pages/AddTutorial.js
@@ -1,0 +1,14 @@
+import { React, useState } from 'react';
+import { Typography } from '@mui/material';
+
+export function AddTutorial() {
+    return (
+        <div>
+            <Typography component='h1' variant='h5'>
+                Add a Tutorial
+            </Typography>
+        </div>
+    );
+}
+
+export default AddTutorial;

--- a/client/src/pages/AddTutorial.js
+++ b/client/src/pages/AddTutorial.js
@@ -4,15 +4,15 @@ import {
   TextField, 
   Typography 
 } from '@mui/material';
-import { 
-  Chip, 
-  FormControl, 
-  Input, 
-  InputLabel, 
-  makeStyles, 
-  MenuItem, 
-  Select, 
-  useTheme, 
+import {
+  Chip,
+  FormControl,
+  Input,
+  InputLabel,
+  makeStyles,
+  MenuItem,
+  Select,
+  useTheme,
 } from '@material-ui/core';
 import { useQuery } from '@apollo/client';
 import { isEmptyInput } from '../utils/validation';
@@ -55,7 +55,7 @@ function getStyles(category, selectedCategories, theme) {
 export function AddTutorial() {
   const classes = useStyles();
   const theme = useTheme();
-  
+
   const inputDefaultValues = {
     value: '',
     isEmpty: false,
@@ -74,9 +74,9 @@ export function AddTutorial() {
     return <p>Loading...</p>;
   }
 
-  function handleChange (event) {
+  function handleChange(event) {
     setSelectedCategories(event.target.value);
-  };
+  }
 
   function handleSubmit(e) {
     e.preventDefault();
@@ -150,7 +150,9 @@ export function AddTutorial() {
         onChange={(e) => handleOnChange(e.target.value.trim(), setOverview)}
         onBlur={(e) => handleOnBlur(e.target.value, setOverview)}
         error={overview.isEmpty}
-        helperText={overview.isEmpty && 'Please enter an overview of your tutorial'}
+        helperText={
+          overview.isEmpty && 'Please enter an overview of your tutorial'
+        }
         onFocus={() => handleOnFocus(overview, setOverview)}
       />
       <TextField
@@ -163,18 +165,23 @@ export function AddTutorial() {
         onChange={(e) => handleOnChange(e.target.value.trim(), setThumbnail)}
         onBlur={(e) => handleOnBlur(e.target.value, setThumbnail)}
         error={thumbnail.isEmpty}
-        helperText={thumbnail.isEmpty && 'Please enter the URL of a thumbnail for your tutorial'}
+        helperText={
+          thumbnail.isEmpty &&
+          'Please enter the URL of a thumbnail for your tutorial'
+        }
         onFocus={() => handleOnFocus(thumbnail, setThumbnail)}
       />
       <FormControl required className={classes.formControl}>
-        <InputLabel id="categories-label">Categories (choose all that apply)</InputLabel>
+        <InputLabel id='categories-label'>
+          Categories (choose all that apply)
+        </InputLabel>
         <Select
-          labelId="categories-label"
-          id="categories"
+          labelId='categories-label'
+          id='categories'
           multiple
           value={selectedCategories}
           onChange={handleChange}
-          input={<Input id="categories-input" />}
+          input={<Input id='categories-input' />}
           renderValue={(selected) => (
             <div className={classes.chips}>
               {selected.map((value) => (
@@ -185,15 +192,19 @@ export function AddTutorial() {
           MenuProps={MenuProps}
         >
           {categories.map((category) => (
-            <MenuItem key={category.category} value={category.category} style={getStyles(category.category, selectedCategories, theme)}>
+            <MenuItem
+              key={category.category}
+              value={category.category}
+              style={getStyles(category.category, selectedCategories, theme)}
+            >
               {category.category}
             </MenuItem>
           ))}
         </Select>
       </FormControl>
-      <Button
-        type='submit'
-        variant='contained'
+      <Button 
+        type='submit' 
+        variant='contained' 
         sx={{ mt: 3, mb: 2 }}
       >
         Save Your Tutorial

--- a/client/src/pages/AddTutorial.js
+++ b/client/src/pages/AddTutorial.js
@@ -1,14 +1,205 @@
 import { React, useState } from 'react';
-import { Typography } from '@mui/material';
+import { 
+  Button, 
+  TextField, 
+  Typography 
+} from '@mui/material';
+import { 
+  Chip, 
+  FormControl, 
+  Input, 
+  InputLabel, 
+  makeStyles, 
+  MenuItem, 
+  Select, 
+  useTheme, 
+} from '@material-ui/core';
+import { useQuery } from '@apollo/client';
+import { isEmptyInput } from '../utils/validation';
+import { GET_CATEGORIES } from '../utils/queries/categoryQueries';
+
+const useStyles = makeStyles((theme) => ({
+  formControl: {
+    margin: theme.spacing(1),
+    width: `100%`,
+  },
+  chips: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  chip: {
+    margin: 2,
+  },
+}));
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+    },
+  },
+};
+
+function getStyles(category, selectedCategories, theme) {
+  return {
+    fontWeight:
+      selectedCategories.indexOf(category) === -1
+        ? theme.typography.fontWeightRegular
+        : theme.typography.fontWeightBold,
+  };
+}
 
 export function AddTutorial() {
-    return (
-        <div>
-            <Typography component='h1' variant='h5'>
-                Add a Tutorial
-            </Typography>
-        </div>
-    );
+  const classes = useStyles();
+  const theme = useTheme();
+  
+  const inputDefaultValues = {
+    value: '',
+    isEmpty: false,
+    isValid: true,
+  };
+
+  const [title, setTitle] = useState(inputDefaultValues);
+  const [overview, setOverview] = useState(inputDefaultValues);
+  const [thumbnail, setThumbnail] = useState(inputDefaultValues);
+  const [selectedCategories, setSelectedCategories] = useState([]);
+
+  const { loading, data } = useQuery(GET_CATEGORIES);
+  const categories = data?.categories || [];
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  function handleChange (event) {
+    setSelectedCategories(event.target.value);
+  };
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    console.log({
+      title: data.get('title'),
+      overview: data.get('overview'),
+      thumbnail: data.get('thumbnail'),
+      categories: data.get('categories'),
+    });
+  }
+
+  // set a new value to the state.value associated to the text field that invokes this function
+  function handleOnChange(inputValue, setState) {
+    setState((otherValues) => ({
+      ...otherValues,
+      value: inputValue,
+    }));
+  }
+
+  // verify that the input is non-blank
+  // set the associated state to display the appropriate error message based on the validation result
+  function handleOnBlur(inputValue, setState) {
+    // ensure that the input is not empty
+    if (isEmptyInput(inputValue)) {
+      setState((otherValues) => ({
+        ...otherValues,
+        isEmpty: true,
+      }));
+      return;
+    }
+  }
+
+  // update the state to clear the error when the user focuses on that field
+  function handleOnFocus(state, setState) {
+    // change state to remove the error message on Focus if previously input was empty
+    if (state.isEmpty) {
+      setState((otherValues) => ({
+        ...otherValues,
+        isEmpty: false,
+      }));
+      return;
+    }
+  }
+
+  return (
+    <div>
+      <Typography component='h1' variant='h5'>
+        Add a Tutorial
+      </Typography>
+      <TextField
+        required
+        fullWidth
+        id='title'
+        name='title'
+        label='Title'
+        margin='normal'
+        onChange={(e) => handleOnChange(e.target.value.trim(), setTitle)}
+        onBlur={(e) => handleOnBlur(e.target.value, setTitle)}
+        error={title.isEmpty}
+        helperText={title.isEmpty && 'Please enter a title for your tutorial'}
+        onFocus={() => handleOnFocus(title, setTitle)}
+      />
+      <TextField
+        required
+        fullWidth
+        id='overview'
+        name='overview'
+        label='Overview (1-2 sentences)'
+        margin='normal'
+        onChange={(e) => handleOnChange(e.target.value.trim(), setOverview)}
+        onBlur={(e) => handleOnBlur(e.target.value, setOverview)}
+        error={overview.isEmpty}
+        helperText={overview.isEmpty && 'Please enter an overview of your tutorial'}
+        onFocus={() => handleOnFocus(overview, setOverview)}
+      />
+      <TextField
+        required
+        fullWidth
+        id='thumbnail'
+        name='thumbnail'
+        label='Thumbnail Image URL'
+        margin='normal'
+        onChange={(e) => handleOnChange(e.target.value.trim(), setThumbnail)}
+        onBlur={(e) => handleOnBlur(e.target.value, setThumbnail)}
+        error={thumbnail.isEmpty}
+        helperText={thumbnail.isEmpty && 'Please enter the URL of a thumbnail for your tutorial'}
+        onFocus={() => handleOnFocus(thumbnail, setThumbnail)}
+      />
+      <FormControl required className={classes.formControl}>
+        <InputLabel id="categories-label">Categories (choose all that apply)</InputLabel>
+        <Select
+          labelId="categories-label"
+          id="categories"
+          multiple
+          value={selectedCategories}
+          onChange={handleChange}
+          input={<Input id="categories-input" />}
+          renderValue={(selected) => (
+            <div className={classes.chips}>
+              {selected.map((value) => (
+                <Chip key={value} label={value} className={classes.chip} />
+              ))}
+            </div>
+          )}
+          MenuProps={MenuProps}
+        >
+          {categories.map((category) => (
+            <MenuItem key={category.category} value={category.category} style={getStyles(category.category, selectedCategories, theme)}>
+              {category.category}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <Button
+        type='submit'
+        variant='contained'
+        sx={{ mt: 3, mb: 2 }}
+      >
+        Save Your Tutorial
+      </Button>
+    </div>
+  );
 }
 
 export default AddTutorial;

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -1,5 +1,4 @@
-import Home from './Home';
-import SignUp from './SignUp';
-import SignIn from './SignIn';
-
-export { Home, SignUp, SignIn };
+export * from './AddTutorial';
+export * from './Home';
+export * from './SignIn';
+export * from './SignUp';

--- a/client/src/utils/queries/categoryQueries.js
+++ b/client/src/utils/queries/categoryQueries.js
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client';
+
+export const GET_CATEGORIES = gql`
+  query GetCategories {
+    categories {
+      _id
+      category
+    }
+  }
+`;


### PR DESCRIPTION
Set up the skeleton of the page to add a new tutorial (url: `/tutorials/new`).

**Important Notes:**
- This PR only adds the fields to the page and verifies that text is entered `onBlur` (`onBlur` not set up for categories yet).
- I had to add a query to get the categories from the database. This will need to be reconciled with the same query added in Ryan's branch.
- To be done in future PRs:
    - Set up onBlur functionality for the categories field
    - Try to consolidate `onChange` functions for the text fields and the categories field (currently two separate functions)
    - Connect the data to the back end on submit (includes figuring out how to get the user's information to set as the teacher)
    - Styling