### PR TITLE
Bug fix/userDefs auth 

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "express": "^4.17.2",
     "graphql": "^16.3.0",
     "jsonwebtoken": "^9.0.1",
+    "jwt-decode": "^3.1.2",
     "mongoose": "^7.0.2"
   },
   "devDependencies": {

--- a/server/schemas/userDefs.js
+++ b/server/schemas/userDefs.js
@@ -33,7 +33,7 @@ const userTypeDefs = gql`
     removeTutorialfromUser(tutorialId: ID!): Tutorial
   }
 `;
-// after auth works succeffully, change addUser to return Auth type instead of User
+
 const userResolvers = {
   Query: {
     user: async (parent, { _id }) => {

--- a/server/schemas/userDefs.js
+++ b/server/schemas/userDefs.js
@@ -25,7 +25,7 @@ const userTypeDefs = gql`
 
 	type Mutation {
 		login(email: String!, password: String!): Auth
-		addUser(username: String!, email: String!, password: String!): Auth
+		addUser(username: String!, email: String!, password: String!): User
 		removeUser: User
 
 		addTutorialtoUser(tutorialId: ID!): Tutorial
@@ -72,42 +72,33 @@ const userResolvers = {
 		addUser: async (parent, { username, email, password }) => {
 			try {
 				const user = await User.create({ username, email, password });
-				const token = signToken(user);
+				// const token = signToken(user);
+				console.log(user)
+				return user;
 			} catch (err) {
 				throw new Error(err);
 			}
 
-			return { token, user };
 		},
 
 		login: async (parent, { email, password }) => {
 			try {
 				const user = await User.findOne({ email });
-			} catch (err) {
-				throw new Error(err);
-			}
 
-			if (!user) {
-				throw new AuthenticationError('No User with this email found!');
-			}
-
-			try {
+				if (!user) {
+					throw new AuthenticationError('No User with this email found!');
+				}
 				const correctPw = await user.isCorrectPassword(password);
+
+				if (!correctPw) {
+					throw new AuthenticationError('Incorrect Password!');
+				}
+				// 	const token = signToken(user);
+				return { user };
+				// return { token, user };
 			} catch (err) {
 				throw new Error(err);
 			}
-
-			if (!correctPw) {
-				throw new AuthenticationError('Incorrect Password!');
-			}
-
-			try {
-				const token = signToken(user);
-			} catch (err) {
-				throw new Error(err);
-			}
-
-			return { token, user };
 		},
 
 		removeUser: async (parent, args, context) => {

--- a/server/schemas/userDefs.js
+++ b/server/schemas/userDefs.js
@@ -33,7 +33,7 @@ const userTypeDefs = gql`
 		removeTutorialfromUser(tutorialId: ID!): Tutorial
 	}
 `;
-
+// after auth works succeffully, change addUser to return Auth type instead of User
 const userResolvers = {
 	Query: {
 		user: async (parent, { _id }) => {

--- a/server/schemas/userDefs.js
+++ b/server/schemas/userDefs.js
@@ -25,7 +25,7 @@ const userTypeDefs = gql`
 
   type Mutation {
     login(email: String!, password: String!): Auth
-    addUser(username: String!, email: String!, password: String!): User
+    addUser(username: String!, email: String!, password: String!): Auth
     removeUser: User
 
     addTutorialtoUser(tutorialId: ID!): Tutorial
@@ -72,10 +72,8 @@ const userResolvers = {
     addUser: async (parent, { username, email, password }) => {
       try {
         const user = await User.create({ username, email, password });
-        // const token = signToken(user);
-        console.log({ user });
-        return { user };
-        // return { token, user };
+        const token = signToken(user);
+        return { token, user };
       } catch (err) {
         throw new Error(err);
       }
@@ -93,10 +91,8 @@ const userResolvers = {
         if (!correctPw) {
           throw new AuthenticationError('Incorrect Password!');
         }
-        // 	const token = signToken(user);
-        console.log({ user });
-        return { user };
-        // return { token, user };
+        const token = signToken(user);
+        return { token, user };
       } catch (err) {
         throw new Error(err);
       }

--- a/server/schemas/userDefs.js
+++ b/server/schemas/userDefs.js
@@ -4,149 +4,150 @@ const { User } = require('../models');
 const { signToken } = require('../utils/auth');
 
 const userTypeDefs = gql`
-	type User {
-		_id: ID
-		username: String
-		email: String
-		password: String
-		tutorials: [Tutorial]
-	}
+  type User {
+    _id: ID
+    username: String
+    email: String
+    password: String
+    tutorials: [Tutorial]
+  }
 
-	type Auth {
-		token: ID!
-		user: User
-	}
+  type Auth {
+    token: ID!
+    user: User
+  }
 
-	type Query {
-		me: User
-		user(_id: ID!): User
-		users: [User]!
-	}
+  type Query {
+    me: User
+    user(_id: ID!): User
+    users: [User]!
+  }
 
-	type Mutation {
-		login(email: String!, password: String!): Auth
-		addUser(username: String!, email: String!, password: String!): User
-		removeUser: User
+  type Mutation {
+    login(email: String!, password: String!): Auth
+    addUser(username: String!, email: String!, password: String!): User
+    removeUser: User
 
-		addTutorialtoUser(tutorialId: ID!): Tutorial
+    addTutorialtoUser(tutorialId: ID!): Tutorial
 
-		removeTutorialfromUser(tutorialId: ID!): Tutorial
-	}
+    removeTutorialfromUser(tutorialId: ID!): Tutorial
+  }
 `;
 // after auth works succeffully, change addUser to return Auth type instead of User
 const userResolvers = {
-	Query: {
-		user: async (parent, { _id }) => {
-			try {
-				return User.findOne({ _id: _id });
-			} catch (err) {
-				throw new Error(err);
-			}
-		},
+  Query: {
+    user: async (parent, { _id }) => {
+      try {
+        return User.findOne({ _id: _id });
+      } catch (err) {
+        throw new Error(err);
+      }
+    },
 
-		users: async () => {
-			try {
-				return User.find();
-			} catch (err) {
-				throw new Error(err);
-			}
-		},
+    users: async () => {
+      try {
+        return User.find();
+      } catch (err) {
+        throw new Error(err);
+      }
+    },
 
-		me: async (parent, args, context) => {
-			if (context.user) {
-				try {
-					const userData = await User.findOne({ _id: context.user._id })
-						.select('-__v -password')
-						.populate('tutorials');
-				} catch (err) {
-					throw new Error(err);
-				}
-				return userData;
-			}
+    me: async (parent, args, context) => {
+      if (context.user) {
+        try {
+          const userData = await User.findOne({ _id: context.user._id })
+            .select('-__v -password')
+            .populate('tutorials');
+        } catch (err) {
+          throw new Error(err);
+        }
+        return userData;
+      }
 
-			throw new AuthenticationError('Not logged in');
-		},
-	},
+      throw new AuthenticationError('Not logged in');
+    },
+  },
 
-	Mutation: {
-		addUser: async (parent, { username, email, password }) => {
-			try {
-				const user = await User.create({ username, email, password });
-				// const token = signToken(user);
-				console.log(user)
-				return user;
-			} catch (err) {
-				throw new Error(err);
-			}
+  Mutation: {
+    addUser: async (parent, { username, email, password }) => {
+      try {
+        const user = await User.create({ username, email, password });
+        // const token = signToken(user);
+        console.log({ user });
+        return { user };
+        // return { token, user };
+      } catch (err) {
+        throw new Error(err);
+      }
+    },
 
-		},
+    login: async (parent, { email, password }) => {
+      try {
+        const user = await User.findOne({ email });
 
-		login: async (parent, { email, password }) => {
-			try {
-				const user = await User.findOne({ email });
+        if (!user) {
+          throw new AuthenticationError('No User with this email found!');
+        }
+        const correctPw = await user.isCorrectPassword(password);
 
-				if (!user) {
-					throw new AuthenticationError('No User with this email found!');
-				}
-				const correctPw = await user.isCorrectPassword(password);
+        if (!correctPw) {
+          throw new AuthenticationError('Incorrect Password!');
+        }
+        // 	const token = signToken(user);
+        console.log({ user });
+        return { user };
+        // return { token, user };
+      } catch (err) {
+        throw new Error(err);
+      }
+    },
 
-				if (!correctPw) {
-					throw new AuthenticationError('Incorrect Password!');
-				}
-				// 	const token = signToken(user);
-				return { user };
-				// return { token, user };
-			} catch (err) {
-				throw new Error(err);
-			}
-		},
+    removeUser: async (parent, args, context) => {
+      if (context.user) {
+        try {
+          return User.findOneAndDelete({ _id: context.user._id });
+        } catch (err) {
+          throw new Error(err);
+        }
+      }
+      throw new AuthenticationError('You need to be logged in!');
+    },
 
-		removeUser: async (parent, args, context) => {
-			if (context.user) {
-				try {
-					return User.findOneAndDelete({ _id: context.user._id });
-				} catch (err) {
-					throw new Error(err);
-				}
-			}
-			throw new AuthenticationError('You need to be logged in!');
-		},
+    addTutorialtoUser: async (parent, { _id, tutorialId }, context) => {
+      if (context.user) {
+        try {
+          return User.findOneAndUpdate(
+            { _id: _id },
+            {
+              $addToSet: { tutorials: tutorialId },
+            },
+            {
+              new: true,
+              runValidators: true,
+            }
+          );
+        } catch (err) {
+          throw new Error(err);
+        }
+      }
+      throw new AuthenticationError('You need to be logged in!');
+    },
 
-		addTutorialtoUser: async (parent, { _id, tutorialId }, context) => {
-			if (context.user) {
-				try {
-					return User.findOneAndUpdate(
-						{ _id: _id },
-						{
-							$addToSet: { tutorials: tutorialId },
-						},
-						{
-							new: true,
-							runValidators: true,
-						}
-					);
-				} catch (err) {
-					throw new Error(err);
-				}
-			}
-			throw new AuthenticationError('You need to be logged in!');
-		},
-
-		removeTutorialfromUser: async (parent, { tutorialId }, context) => {
-			if (context.user) {
-				try {
-					return User.findOneAndUpdate(
-						{ _id: context.user._id },
-						{ $pull: { tutorials: tutorialId } },
-						{ new: true }
-					);
-				} catch (err) {
-					throw new Error(err);
-				}
-			}
-			throw new AuthenticationError('You need to be logged in!');
-		},
-	},
+    removeTutorialfromUser: async (parent, { tutorialId }, context) => {
+      if (context.user) {
+        try {
+          return User.findOneAndUpdate(
+            { _id: context.user._id },
+            { $pull: { tutorials: tutorialId } },
+            { new: true }
+          );
+        } catch (err) {
+          throw new Error(err);
+        }
+      }
+      throw new AuthenticationError('You need to be logged in!');
+    },
+  },
 };
 
 module.exports = { userTypeDefs, userResolvers };

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const jwt = require('jsonwebtoken');
 
 const secret = process.env.SECRET;


### PR DESCRIPTION
Modified the Mutations `addUser` and `login` mutations since they didn't work. Each of this mutations had multiple try/catch blocks and since user data were returned within the first try/catch block, the others couldn't read `user` value as it was declared in local scope of the first try/catch block.
Ran Prettier.

To test run `addUser` and `login` mutations in the Apollo `graphql` excluding `token` and `tutorials`
Worked for me successfully with this modifications. 


NOTE: 
Front end still doesn't work.
Commented out `token` code in this mutations as it also doesn't seem to work properly and it would be easier to resolve one problem at a time