### PR TITLE
Add nav categories

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -11,6 +11,8 @@ import {
 } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 import { NavLink } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { GET_CATEGORIES } from '../utils/queries';
 
 const useStyles = makeStyles((theme) => {
   return {
@@ -86,6 +88,18 @@ function Navbar({ darkMode, onDarkModeChange }) {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState(null);
 
+  const { loading, data } = useQuery(GET_CATEGORIES);
+  const categories = data?.categories || [];
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  const linkStyle = {
+    textDecoration: 'none',
+    color: 'inherit'
+  };
+
   function handleMenuOpen(event) {
     setAnchorEl(event.currentTarget);
   }
@@ -127,9 +141,11 @@ function Navbar({ darkMode, onDarkModeChange }) {
             open={Boolean(anchorEl)}
             onClose={handleMenuClose}
           >
-            <MenuItem onClick={handleMenuClose}>Category 1</MenuItem>
-            <MenuItem onClick={handleMenuClose}>Category 2</MenuItem>
-            <MenuItem onClick={handleMenuClose}>Category 3</MenuItem>
+            {categories.map((category) => (
+              <NavLink to={'category/' + category.category} style={linkStyle}>
+                <MenuItem onClick={handleMenuClose}>{category.category}</MenuItem>
+              </NavLink>
+            ))}
           </Menu>
         </div>
         <NavLink to='/signup'>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -97,7 +97,7 @@ function Navbar({ darkMode, onDarkModeChange }) {
 
   const linkStyle = {
     textDecoration: 'none',
-    color: 'inherit'
+    color: 'inherit',
   };
 
   function handleMenuOpen(event) {
@@ -143,24 +143,20 @@ function Navbar({ darkMode, onDarkModeChange }) {
           >
             {categories.map((category) => (
               <NavLink to={'category/' + category.category} style={linkStyle}>
-                <MenuItem onClick={handleMenuClose}>{category.category}</MenuItem>
+                <MenuItem onClick={handleMenuClose}>
+                  {category.category}
+                </MenuItem>
               </NavLink>
             ))}
           </Menu>
         </div>
         <NavLink to='/signup'>
-          <Button
-            variant='contained'
-            className={classes.signUpButton}
-          >
+          <Button variant='contained' className={classes.signUpButton}>
             Sign Up
           </Button>
         </NavLink>
         <NavLink to='/signin'>
-          <Button
-            variant='contained'
-            className={classes.signUpButton}
-          >
+          <Button variant='contained' className={classes.signUpButton}>
             Sign In
           </Button>
         </NavLink>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -12,7 +12,7 @@ import {
 import SearchIcon from '@material-ui/icons/Search';
 import { NavLink } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
-import { GET_CATEGORIES } from '../utils/queries';
+import { GET_CATEGORIES } from '../utils/queries/categoryQueries';
 
 const useStyles = makeStyles((theme) => {
   return {
@@ -142,7 +142,11 @@ function Navbar({ darkMode, onDarkModeChange }) {
             onClose={handleMenuClose}
           >
             {categories.map((category) => (
-              <NavLink to={'category/' + category.category} style={linkStyle}>
+              <NavLink 
+                to={'category/' + category.category} 
+                style={linkStyle} 
+                key={category.category}
+              >
                 <MenuItem onClick={handleMenuClose}>
                   {category.category}
                 </MenuItem>

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -8,12 +8,3 @@ export const QUERY_TUTORIALS = gql`
         thumbnail
     }}
 `;
-
-export const GET_CATEGORIES = gql`
-    query GetCategories {
-        categories {
-            _id
-            category
-        }
-    }
-`

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -9,4 +9,11 @@ export const QUERY_TUTORIALS = gql`
     }}
 `;
 
-
+export const GET_CATEGORIES = gql`
+    query GetCategories {
+        categories {
+            _id
+            category
+        }
+    }
+`


### PR DESCRIPTION
Add query to get categories from the database and use them to populate the categories menu in the navbar.

Note: The category menu links are functional in that they take you to the agreed upon URLs (/category/categoryname, but those pages have not been built out yet.