### PR TITLE
Set error state on categories when no categories selected

### DIFF
--- a/client/src/pages/AddTutorial.js
+++ b/client/src/pages/AddTutorial.js
@@ -74,10 +74,6 @@ export function AddTutorial() {
     return <p>Loading...</p>;
   }
 
-  function handleChange(event) {
-    setSelectedCategories(event.target.value);
-  }
-
   function handleSubmit(e) {
     e.preventDefault();
     const data = new FormData(e.currentTarget);

--- a/client/src/pages/AddTutorial.js
+++ b/client/src/pages/AddTutorial.js
@@ -65,7 +65,7 @@ export function AddTutorial() {
   const [title, setTitle] = useState(inputDefaultValues);
   const [overview, setOverview] = useState(inputDefaultValues);
   const [thumbnail, setThumbnail] = useState(inputDefaultValues);
-  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [selectedCategories, setSelectedCategories] = useState({...inputDefaultValues, value: []});
 
   const { loading, data } = useQuery(GET_CATEGORIES);
   const categories = data?.categories || [];
@@ -171,7 +171,11 @@ export function AddTutorial() {
         }
         onFocus={() => handleOnFocus(thumbnail, setThumbnail)}
       />
-      <FormControl required className={classes.formControl}>
+      <FormControl 
+        required 
+        className={classes.formControl} 
+        error={selectedCategories.isEmpty} 
+      >
         <InputLabel id='categories-label'>
           Categories (choose all that apply)
         </InputLabel>
@@ -179,8 +183,10 @@ export function AddTutorial() {
           labelId='categories-label'
           id='categories'
           multiple
-          value={selectedCategories}
-          onChange={handleChange}
+          value={selectedCategories.value}
+          onChange={(e) => handleOnChange(e.target.value, setSelectedCategories)}
+          onBlur={(e) => handleOnBlur(e.target.value, setSelectedCategories)}
+          onFocus={() => handleOnFocus(selectedCategories, setSelectedCategories)}
           input={<Input id='categories-input' />}
           renderValue={(selected) => (
             <div className={classes.chips}>
@@ -195,7 +201,7 @@ export function AddTutorial() {
             <MenuItem
               key={category.category}
               value={category.category}
-              style={getStyles(category.category, selectedCategories, theme)}
+              style={getStyles(category.category, selectedCategories.value, theme)}
             >
               {category.category}
             </MenuItem>


### PR DESCRIPTION
On the page to add a new tutorial (`/tutorials/new`), this PR sets up the categories field to show the error state if empty on blur.

Notes:
- The first click out of the menu doesn't bring up the error state--I don't think clicking out of the menu is considered blurring, but I'm not certain. The click after clicking outside of the menu brings up the error state. I'm not sure if this can be fixed? I'm also not sure if this is going to cause problems if the next click outside of the menu is the submit button.
- I wasn't able to figure out how to add an error message. I don't think we can use the `helperText` prop like we do on the `TextField`s. There is a `FormHelperText` component that I was trying to render conditionally but I couldn't figure it out and I figured we could try to tackle that later.