### PR TITLE
Add lesson pg

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,6 +10,7 @@ import {
 } from '@apollo/client';
 import './style/App.css';
 import { 
+  AddLessons, 
   AddTutorial,
   Home,
   SignIn, 
@@ -44,6 +45,10 @@ function App() {
             <Route
               path='/tutorials/new'
               element={<AddTutorial />}
+            ></Route>
+            <Route
+              path='/:tutorialId/lessons/add'
+              element={<AddLessons />}
             ></Route>
           </Routes>
         </Router>

--- a/client/src/components/AddLesson.js
+++ b/client/src/components/AddLesson.js
@@ -4,17 +4,7 @@ import {
   TextField, 
   Typography 
 } from '@mui/material';
-// import { useQuery } from '@apollo/client';
 import { isEmptyInput } from '../utils/validation';
-
-
-/*
-tutorialId: ID!
-      name: String!
-      body: String!
-      media: String
-      duration: Int!
-      */
 
 export function AddLesson() {
   const inputDefaultValues = {

--- a/client/src/components/AddLesson.js
+++ b/client/src/components/AddLesson.js
@@ -96,20 +96,12 @@ export function AddLesson() {
         onFocus={() => handleOnFocus(body, setBody)}
       />
       <TextField
-        required
         fullWidth
         id='media'
         name='media'
         label='Media'
         margin='normal'
         onChange={(e) => handleOnChange(e.target.value.trim(), setMedia)}
-        onBlur={(e) => handleOnBlur(e.target.value, setMedia)}
-        error={media.isEmpty}
-        helperText={
-          media.isEmpty &&
-          'Please enter the URL of a media for this lesson'
-        }
-        onFocus={() => handleOnFocus(media, setMedia)}
       />
       <TextField
         required

--- a/client/src/components/AddLesson.js
+++ b/client/src/components/AddLesson.js
@@ -1,0 +1,157 @@
+import { React, useState } from 'react';
+import { 
+  Button, 
+  TextField, 
+  Typography 
+} from '@mui/material';
+// import { useQuery } from '@apollo/client';
+import { isEmptyInput } from '../utils/validation';
+
+
+/*
+tutorialId: ID!
+      name: String!
+      body: String!
+      media: String
+      duration: Int!
+      */
+
+export function AddLesson() {
+  const inputDefaultValues = {
+    value: '',
+    isEmpty: false,
+    isValid: true,
+  };
+
+  const [name, setName] = useState(inputDefaultValues);
+  const [body, setBody] = useState(inputDefaultValues);
+  const [media, setMedia] = useState(inputDefaultValues);
+  const [duration, setDuration] = useState(inputDefaultValues);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    console.log({
+      name: data.get('name'),
+      body: data.get('body'),
+      media: data.get('media'),
+      duration: data.get('duration'),
+    });
+  }
+
+  // set a new value to the state.value associated to the text field that invokes this function
+  function handleOnChange(inputValue, setState) {
+    setState((otherValues) => ({
+      ...otherValues,
+      value: inputValue,
+    }));
+  }
+
+  // verify that the input is non-blank
+  // set the associated state to display the appropriate error message based on the validation result
+  function handleOnBlur(inputValue, setState) {
+    // ensure that the input is not empty
+    if (isEmptyInput(inputValue)) {
+      setState((otherValues) => ({
+        ...otherValues,
+        isEmpty: true,
+      }));
+      return;
+    }
+  }
+
+  // update the state to clear the error when the user focuses on that field
+  function handleOnFocus(state, setState) {
+    // change state to remove the error message on Focus if previously input was empty
+    if (state.isEmpty) {
+      setState((otherValues) => ({
+        ...otherValues,
+        isEmpty: false,
+      }));
+      return;
+    }
+  }
+
+  return (
+    <div>
+      <Typography component='h1' variant='h5'>
+        Add Lessons to Your Tutorial
+      </Typography>
+      <TextField
+        required
+        fullWidth
+        id='name'
+        name='name'
+        label='Name'
+        margin='normal'
+        onChange={(e) => handleOnChange(e.target.value.trim(), setName)}
+        onBlur={(e) => handleOnBlur(e.target.value, setName)}
+        error={name.isEmpty}
+        helperText={name.isEmpty && 'Please enter a name for your lesson'}
+        onFocus={() => handleOnFocus(name, setName)}
+      />
+      <TextField
+        required
+        fullWidth
+        id='body'
+        name='body'
+        label='Body'
+        margin='normal'
+        onChange={(e) => handleOnChange(e.target.value.trim(), setBody)}
+        onBlur={(e) => handleOnBlur(e.target.value, setBody)}
+        error={body.isEmpty}
+        helperText={
+          body.isEmpty && 'Please enter the body of your lesson'
+        }
+        onFocus={() => handleOnFocus(body, setBody)}
+      />
+      <TextField
+        required
+        fullWidth
+        id='media'
+        name='media'
+        label='Media'
+        margin='normal'
+        onChange={(e) => handleOnChange(e.target.value.trim(), setMedia)}
+        onBlur={(e) => handleOnBlur(e.target.value, setMedia)}
+        error={media.isEmpty}
+        helperText={
+          media.isEmpty &&
+          'Please enter the URL of a media for this lesson'
+        }
+        onFocus={() => handleOnFocus(media, setMedia)}
+      />
+      <TextField
+        required
+        fullWidth
+        id='duration'
+        name='duration'
+        label='Duration'
+        margin='normal'
+        onChange={(e) => handleOnChange(e.target.value.trim(), setDuration)}
+        onBlur={(e) => handleOnBlur(e.target.value, setDuration)}
+        error={duration.isEmpty}
+        helperText={
+          duration.isEmpty &&
+          'Please enter the duration of this lesson'
+        }
+        onFocus={() => handleOnFocus(duration, setDuration)}
+      />
+      <Button 
+        variant='contained' 
+        sx={{ mt: 3, mb: 2 }}
+      >
+        Add Another Lesson
+      </Button>
+      <Button 
+        type='submit' 
+        variant='contained' 
+        sx={{ mt: 3, mb: 2 }}
+      >
+        Submit All Lessons
+      </Button>
+    </div>
+  );
+}
+
+export default AddLesson;

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,6 +1,15 @@
-import Navbar from './Navbar';
+import AddLesson from './AddLesson';
 import Carousel from './Carousel';
-import Footer from './Footer';
-import Recommended from './Recommended';
 import Categories from './Categories';
-export { Navbar, Carousel, Footer, Recommended, Categories };
+import Footer from './Footer';
+import Navbar from './Navbar';
+import Recommended from './Recommended';
+
+export { 
+  AddLesson, 
+  Carousel, 
+  Categories, 
+  Footer, 
+  Navbar, 
+  Recommended 
+};

--- a/client/src/pages/AddLessons.js
+++ b/client/src/pages/AddLessons.js
@@ -1,0 +1,12 @@
+import { React } from 'react';
+import { AddLesson } from '../components';
+
+export function AddLessons() {
+  return (
+    <div>
+      <AddLesson />
+    </div>
+  );
+}
+
+export default AddLessons;

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -1,3 +1,4 @@
+export * from './AddLessons';
 export * from './AddTutorial';
 export * from './Home';
 export * from './SignIn';


### PR DESCRIPTION
Sets up the skeleton of adding lessons to a tutorial (`/:tutorialId/lessons/add`). The idea is that there will be a single page for adding all lessons, with a button to continue adding new sets of lesson fields for each lesson they want to add.

Notes:
- You can visit the page in the browser by putting any string in place of `tutorialId`--the page does not rely on the wildcard being a valid tutorial ID so any text in that portion of the URL will route you to the right page.
- I will fine-tune the language of the labels and error messages in a future PR--I just wanted to get the fields on the page in their most basic forms to begin with.