### PR TITLE
Signup/display error message if provided username/email values exist in the DB.

### DIFF
--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -39,7 +39,8 @@ function Copyright(props) {
         }}
       >
         Learnify
-      </a>{' '}
+      </a>
+      {' '}
       {new Date().getFullYear()}
       {'.'}
     </Typography>
@@ -92,10 +93,10 @@ export function SignUp() {
       console.log(err.graphQLErrors[0].message);
       switch (err.graphQLErrors[0].message) {
         case 'Duplicate username':
-          changeIsDuplicateState(setUserName, true);
+          changeIsDuplicateToTrue(setUserName);
           break;
         case 'Duplicate email':
-          changeIsDuplicateState(setEmail, true);
+          changeIsDuplicateToTrue(setEmail);
           break;
         default:
           console.log(
@@ -105,11 +106,19 @@ export function SignUp() {
     }
   }
 
-  // call the function when isDuplicate state change needed for any state
-  function changeIsDuplicateState(setState, value) {
+  // call the function when isDuplicate state key needs to be changed to TRUE for any state
+  function changeIsDuplicateToTrue(setState) {
     setState((otherValues) => ({
       ...otherValues,
-      isDuplicate: value,
+      isDuplicate: true,
+    }));
+  }
+
+  // call the function when isDuplicate state key needs to be changed to FALSE for any state
+  function changeIsDuplicateToFalse(setState) {
+    setState((otherValues) => ({
+      ...otherValues,
+      isDuplicate: false,
     }));
   }
 
@@ -173,13 +182,17 @@ export function SignUp() {
         isValid: true,
       }));
     }
-
-    // change state to remove the error message on Focus if previously password values didn't match
+    // change state to remove the error message on Focus if previously provided password values didn't match
     if (!confirmPassword.isMatch) {
       setConfirmPassword((otherValues) => ({
         ...otherValues,
         isMatch: true,
       }));
+    }
+
+    // change state to remove the error message on Focus if previously provided userName or email values were duplicates in the DB
+    if (state.isDuplicate) {
+      changeIsDuplicateToFalse(setState);
     }
   }
 

--- a/client/src/pages/SignUp.js
+++ b/client/src/pages/SignUp.js
@@ -39,8 +39,7 @@ function Copyright(props) {
         }}
       >
         Learnify
-      </a>
-      {' '}
+      </a>{' '}
       {new Date().getFullYear()}
       {'.'}
     </Typography>
@@ -55,6 +54,7 @@ export function SignUp() {
     isEmpty: false,
     isValid: true,
     isMatch: true,
+    isDuplicate: false,
   };
 
   const [userName, setUserName] = useState(inputDefaultValues);
@@ -88,9 +88,29 @@ export function SignUp() {
       });
       console.log(data.addUser.user);
       Auth.login(data.addUser.token);
-    } catch (e) {
-      console.error(e);
+    } catch (err) {
+      console.log(err.graphQLErrors[0].message);
+      switch (err.graphQLErrors[0].message) {
+        case 'Duplicate username':
+          changeIsDuplicateState(setUserName, true);
+          break;
+        case 'Duplicate email':
+          changeIsDuplicateState(setEmail, true);
+          break;
+        default:
+          console.log(
+            "Apologies, but it seems like something went wrong on our end. We'll work to fix the issue as soon as possible. Please try again later. Thank you for your understanding."
+          );
+      }
     }
+  }
+
+  // call the function when isDuplicate state change needed for any state
+  function changeIsDuplicateState(setState, value) {
+    setState((otherValues) => ({
+      ...otherValues,
+      isDuplicate: value,
+    }));
   }
 
   // set a new value to the state.value associated to the text field that invokes this function
@@ -228,10 +248,16 @@ export function SignUp() {
                   onBlur={(e) =>
                     handleOnBlur(e.target.value, e.target.id, setUserName)
                   }
-                  error={userName.isEmpty || !userName.isValid}
+                  error={
+                    userName.isEmpty ||
+                    !userName.isValid ||
+                    userName.isDuplicate
+                  }
                   helperText={
                     (userName.isEmpty && 'Username field is required') ||
-                    (!userName.isValid && notValidUserNameErrorMessage)
+                    (!userName.isValid && notValidUserNameErrorMessage) ||
+                    (userName.isDuplicate &&
+                      "The username address you've provided is already in use!")
                   }
                   onFocus={() => handleOnFocus(userName, setUserName)}
                 />
@@ -253,11 +279,13 @@ export function SignUp() {
                   onBlur={(e) =>
                     handleOnBlur(e.target.value, e.target.id, setEmail)
                   }
-                  error={!email.isValid || email.isEmpty}
+                  error={!email.isValid || email.isEmpty || email.isDuplicate}
                   helperText={
                     (email.isEmpty && 'Email field is required') ||
                     (!email.isValid &&
-                      'Kindly provide a legitimate email address')
+                      'Kindly provide a legitimate email address') ||
+                    (email.isDuplicate &&
+                      "The email you've provided is already in use!")
                   }
                   onFocus={() => handleOnFocus(email, setEmail)}
                 />

--- a/server/.envExample
+++ b/server/.envExample
@@ -1,3 +1,5 @@
 PORT='your port'
 MONGODB_URI='mongodb://127.0.0.1:27017/your_DB_name'
 SECRET='secret'
+REACT_APP_STRIPE_PUBLISHABLE_KEY='your_key'
+REACT_APP_STRIPE_SECRET_KEY='your_secret'

--- a/server/.envExample
+++ b/server/.envExample
@@ -1,5 +1,0 @@
-PORT='your port'
-MONGODB_URI='mongodb://127.0.0.1:27017/your_DB_name'
-SECRET='secret'
-REACT_APP_STRIPE_PUBLISHABLE_KEY='your_key'
-REACT_APP_STRIPE_SECRET_KEY='your_secret'

--- a/server/schemas/userDefs.js
+++ b/server/schemas/userDefs.js
@@ -1,5 +1,4 @@
 const { gql, AuthenticationError } = require('apollo-server-express');
-
 const { User } = require('../models');
 const { signToken } = require('../utils/auth');
 
@@ -75,7 +74,12 @@ const userResolvers = {
         const token = signToken(user);
         return { token, user };
       } catch (err) {
-        throw new Error(err);
+        let message = 'Server error'
+
+        if (err.message.includes('duplicate')) {
+          message = 'Duplicate ' + (err.message.includes('email') ? 'email' : 'username');
+        }
+        throw new Error(message)
       }
     },
 


### PR DESCRIPTION
- Change the functionality of `addUser` Mutation query in the `userDefs` to return an explicit error in case if provided username/email already exist in the username.
- Based on that error message front end changes the state for the field where duplicated value was provided and error message will be displayed.
- On hover of that field error message should disappear (we can be changed the condition that triggers error removal to any other action if we'd like)
- If provided username/email doesn't exist in the DB yet, error shouldn't be displayed and the user should be added to the DB.

To do:

- Create a <p> section to conditionally display an error if the error returned from the server is a server error and not a duplicate error.
- Clear the text field value (didn't do it at this stage to not re-enter the values after each submit for testing purpose)

Question:
Do we want duplicated input values error message do disappear on Focus or on the submit button during user's second try to provide their credentials?

closes #69 
closes #110 
closes #111 