### PR TITLE
Remove erroneous export from /src/components/index.js

### DIFF
--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -8,7 +8,6 @@ import TutorialContext from './TutorialContextProvider';
 import ViewLesson from './ViewLesson';
 
 export {
-  AddLesson,
   Carousel,
   Categories,
   CheckoutForm,


### PR DESCRIPTION
This PR removes the export of the `AddLesson` component, which I deleted in a previous PR but forgot to delete the export of.