### PR TITLE
replace useContext with useParams to fix error on tutorial page refresh

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -23,7 +23,7 @@ import {
   SignUp,
   ViewTutorial,
 } from './pages';
-import { Footer, Navbar, TutorialContext, ViewLesson } from './components';
+import { Footer, Navbar } from './components';
 
 const httpLink = createHttpLink({
   uri: '/graphql',
@@ -61,46 +61,45 @@ function App() {
       <ApolloProvider client={client}>
         <Router>
           <Navbar />
-          <TutorialContext.Provider value={{ tutorialId, setTutorialId }}>
-            <Routes>
-              <Route
-                path='/'
-                element={<Home />}
-              ></Route>
-              <Route
-                path='/signup'
-                element={<SignUp />}
-              ></Route>
-              <Route
-                path='/signin'
-                element={<SignIn />}
-              ></Route>
-              <Route
-                path='/tutorial/:tutorialId'
-                element={<ViewTutorial />}
-              ></Route>
-              <Route
-                path='/tutorials/new'
-                element={<AddTutorial />}
-              ></Route>
-              <Route
-                path='/:tutorialId/lessons/add'
-                element={<AddLessons />}
-              ></Route>
-              <Route
-                path='/payment'
-                element={<Payment />}
-              ></Route>
-              <Route
-                path='/careers'
-                element={<Careers />}
-              ></Route>
-              <Route
-                path='/tutorial/:tutorialId/lesson/:lessonId'
-                element={<ViewTutorial />}
-              ></Route>
-            </Routes>
-          </TutorialContext.Provider>
+
+          <Routes>
+            <Route
+              path='/'
+              element={<Home />}
+            ></Route>
+            <Route
+              path='/signup'
+              element={<SignUp />}
+            ></Route>
+            <Route
+              path='/signin'
+              element={<SignIn />}
+            ></Route>
+            <Route
+              path='/tutorial/:tutorialId'
+              element={<ViewTutorial />}
+            ></Route>
+            <Route
+              path='/tutorials/new'
+              element={<AddTutorial />}
+            ></Route>
+            <Route
+              path='/:tutorialId/lessons/add'
+              element={<AddLessons />}
+            ></Route>
+            <Route
+              path='/payment'
+              element={<Payment />}
+            ></Route>
+            <Route
+              path='/careers'
+              element={<Careers />}
+            ></Route>
+            <Route
+              path='/tutorial/:tutorialId/lesson/:lessonId'
+              element={<ViewTutorial />}
+            ></Route>
+          </Routes>
         </Router>
         <Footer />
       </ApolloProvider>

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -1,4 +1,4 @@
-import { React, useContext, useState } from 'react';
+import { React, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { Card, CardContent, Typography, IconButton } from '@material-ui/core';
@@ -6,7 +6,6 @@ import { ArrowBack, ArrowForward } from '@material-ui/icons';
 import { useQuery } from '@apollo/client';
 import { GET_TUTORIALS } from '../utils/queries/tutorialQueries';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { TutorialContext } from '../components';
 
 const useStyles = makeStyles((theme) => ({
   recommendations: {
@@ -52,15 +51,6 @@ function Recommended() {
   const classes = useStyles();
   const theme = useTheme();
   const isFullScreen = useMediaQuery(theme.breakpoints.up('md')); // Check if screen is full screen (md breakpoint)
-
-  //CONTEXT management
-  const { tutorialId, setTutorialId } = useContext(TutorialContext);
-  //set tutorialId context based on which tutorial is clicked by the user
-  const handleTutorialContext = (tutorialId) => {
-    //  set state to clicked tutorialId
-    setTutorialId(tutorialId);
-    console.log(tutorialId);
-  };
 
   //STATE management
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -108,7 +98,6 @@ function Recommended() {
               <Link
                 to={`/tutorial/${tutorial._id}`}
                 key={tutorial._id}
-                onClick={() => handleTutorialContext(tutorial._id)}
               >
                 <Typography className={classes.cardTitle}>
                   {tutorial.title}

--- a/client/src/components/TutorialContextProvider.js
+++ b/client/src/components/TutorialContextProvider.js
@@ -1,6 +1,0 @@
-import { createContext } from 'react';
-
-//initialize context for tutorial
-export const TutorialContext = createContext();
-
-export default TutorialContext;

--- a/client/src/components/ViewLesson.js
+++ b/client/src/components/ViewLesson.js
@@ -3,10 +3,8 @@ import { useParams } from 'react-router-dom';
 
 //Material-UI imports
 import {
-  Button,
   Card,
   CardActionArea,
-  CardActions,
   CardContent,
   CardMedia,
   Container,
@@ -18,11 +16,7 @@ import {
 import { useQuery } from '@apollo/client';
 import { GET_LESSON } from '../utils/queries/lessonQueries';
 
-
-
 export function ViewLesson() {
-
-
   //get index and ID from URL and get associated lesson data from db
   const { index, lessonId } = useParams();
   const { loading, err, data } = useQuery(GET_LESSON, {
@@ -43,7 +37,6 @@ export function ViewLesson() {
 
   //destructure fields from lesson object
   const { name, body, media, duration } = lesson;
-
 
   return (
     <Container>

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -4,7 +4,6 @@ import CheckoutForm from './CheckoutForm';
 import Footer from './Footer';
 import Navbar from './Navbar';
 import Recommended from './Recommended';
-import TutorialContext from './TutorialContextProvider';
 import ViewLesson from './ViewLesson';
 
 export {
@@ -14,6 +13,5 @@ export {
   Footer,
   Navbar,
   Recommended,
-  TutorialContext,
   ViewLesson,
 };

--- a/client/src/pages/ViewTutorial.js
+++ b/client/src/pages/ViewTutorial.js
@@ -1,9 +1,9 @@
-import { React, useContext, useState } from 'react';
+import { React, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 //import Learnify components
 import { ViewLesson } from '../components';
-import { TutorialContext } from '../components';
 
 //Material-UI imports
 import clsx from 'clsx';
@@ -58,8 +58,8 @@ const useStyles = makeStyles((theme) => ({
 export function ViewTutorial() {
   const classes = useStyles();
 
-  //declare tutorialId from TutorialContext
-  const { tutorialId } = useContext(TutorialContext);
+  //get tutorialId from URL
+  const { tutorialId } = useParams();
   console.log(tutorialId);
 
   //declare State variables
@@ -101,7 +101,6 @@ export function ViewTutorial() {
   const username = teacher?.[0]?.username;
   const duration = tutorial.totalDuration;
   const numberofLessons = tutorial.lessons.length;
-  
 
   //map categories array for use on/around 180
   function categoryList(categories) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "concurrently": "^5.3.0"
   }
 }


### PR DESCRIPTION
In order to fix the error "Tutorial not found" encountered on refreshing a page at the /tutorial/:tutorialId/lesson/:lessonId route, I removed code related to use/setContext in the following files:
-App.js
-ViewTutorial.js
-Recommended.js
-components / index.js
-TutorialContextProvider.js (file removed)

useParams was use in TutorialView.js instead - the previously encountered issues with creating the URL from the lesson list array ( `function lessonList` on line 121).

Test functionality by navigating to a tutorial, viewing at least one lesson, and refreshing the page. The state will be reset so the lesson is no longer visible, but the tutorial should still be visible and the lesson links should still function.
