### PR TITLE
Show lesson save

### DIFF
--- a/client/src/components/ViewLesson.js
+++ b/client/src/components/ViewLesson.js
@@ -18,15 +18,18 @@ import {
 import { useQuery } from '@apollo/client';
 import { GET_LESSON } from '../utils/queries/lessonQueries';
 
-
-
-export function ViewLesson() {
-
-
+export function ViewLesson({ lessonFromAddLessons, stylesFromAddLesson }) {
   //get index and ID from URL and get associated lesson data from db
   const { index, lessonId } = useParams();
+
+  // If lesson was passed from AddLessons use that id to get lesson
+  // otherwise use lessonId from useParams()
   const { loading, err, data } = useQuery(GET_LESSON, {
-    variables: { lessonId: lessonId },
+    variables: { 
+      lessonId: lessonFromAddLessons ? 
+        lessonFromAddLessons._id : 
+        lessonId 
+    },
   });
   console.log(loading, err, data);
   if (loading) {
@@ -46,7 +49,7 @@ export function ViewLesson() {
 
 
   return (
-    <Container>
+    <Container style={stylesFromAddLesson}>
       <Grid
         container
         justifyContent='center'

--- a/client/src/pages/AddLessons.js
+++ b/client/src/pages/AddLessons.js
@@ -3,17 +3,8 @@ import { React, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 // Material UI imports
-import { 
-  Box,
-  Button, 
-  TextField, 
-  Typography,
-} from '@mui/material';
-import { 
-  Chip, 
-  Divider, 
-  makeStyles 
-} from '@material-ui/core';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { Chip, Divider, makeStyles } from '@material-ui/core';
 
 // Imports for interacting with the db
 import { useMutation, useQuery } from '@apollo/client';
@@ -61,20 +52,20 @@ export function AddLessons() {
   const [addLesson, { error: lessonError }] = useMutation(ADD_LESSON, {
     update(cache, { data: { addLesson } }) {
       try {
-        const { tutorial } = cache.readQuery({ 
-          query: GET_TUTORIAL, 
-          variables: { tutorialId } 
+        const { tutorial } = cache.readQuery({
+          query: GET_TUTORIAL,
+          variables: { tutorialId },
         });
         const { lessons } = tutorial;
 
         cache.writeQuery({
           query: GET_TUTORIAL,
           variables: { tutorialId },
-          data: { 
+          data: {
             tutorial: {
               ...tutorial,
-              lessons: [...lessons, addLesson]
-            } 
+              lessons: [...lessons, addLesson],
+            },
           },
         });
       } catch (error) {
@@ -118,7 +109,7 @@ export function AddLessons() {
     return (
       <>
         {lessons.map((lesson) => (
-          <ViewLesson 
+          <ViewLesson
             key={lesson._id}
             lessonFromAddLessons={lesson}
             stylesFromAddLesson={stylesFromAddLesson}
@@ -206,12 +197,7 @@ export function AddLessons() {
         Tutorial: {tutorial.title}
       </Typography>
       <Box direction='row'>{categoryList(categories)}</Box>
-      <Box 
-        component='form' 
-        noValidate 
-        onSubmit={handleSubmit} 
-        sx={{ mt: 1 }}
-      >
+      <Box component='form' noValidate onSubmit={handleSubmit} sx={{ mt: 1 }}>
         <TextField
           required
           fullWidth
@@ -223,9 +209,7 @@ export function AddLessons() {
           onChange={(e) => handleOnChange(e.target.value, setName)}
           onBlur={(e) => handleOnBlur(e.target.value, setName)}
           error={name.isEmpty}
-          helperText={
-            name.isEmpty && 'Please enter the name of this lesson'
-          }
+          helperText={name.isEmpty && 'Please enter the name of this lesson'}
           onFocus={() => handleOnFocus(name, setName)}
         />
         <TextField
@@ -239,9 +223,7 @@ export function AddLessons() {
           onChange={(e) => handleOnChange(e.target.value, setBody)}
           onBlur={(e) => handleOnBlur(e.target.value, setBody)}
           error={body.isEmpty}
-          helperText={
-            body.isEmpty && 'Please enter the body of this lesson'
-          }
+          helperText={body.isEmpty && 'Please enter the body of this lesson'}
           onFocus={() => handleOnFocus(body, setBody)}
         />
         <TextField
@@ -265,33 +247,30 @@ export function AddLessons() {
           onBlur={(e) => handleOnBlur(e.target.value, setDuration)}
           error={duration.isEmpty}
           helperText={
-            duration.isEmpty && 'Please enter the time to complete the process(es) in this lesson'
+            duration.isEmpty &&
+            'Please enter the time to complete the process(es) in this lesson'
           }
           onFocus={() => handleOnFocus(duration, setDuration)}
         />
-        <Button 
-          type='submit' 
-          variant='contained' 
-          sx={{ mt: 3, mb: 2 }}
-        >
+        <Button type='submit' variant='contained' sx={{ mt: 3, mb: 2 }}>
           Save Lesson
         </Button>
       </Box>
       <Divider variant='middle' />
-      <Typography 
-        component='h2' 
+      <Typography
+        component='h2'
         variant='h5'
         style={{
-          margin: '2rem 0'
+          margin: '2rem 0',
         }}
       >
         Lessons in This Tutorial
       </Typography>
-      {
-        lessons && lessons.length > 0 ?
-        lessonList(lessons) :
+      {lessons && lessons.length > 0 ? (
+        lessonList(lessons)
+      ) : (
         <p>No lessons yet! Add one above.</p>
-      }
+      )}
     </div>
   );
 }

--- a/client/src/pages/AddLessons.js
+++ b/client/src/pages/AddLessons.js
@@ -9,7 +9,11 @@ import {
   TextField, 
   Typography,
 } from '@mui/material';
-import { Chip, makeStyles } from '@material-ui/core';
+import { 
+  Chip, 
+  Divider, 
+  makeStyles 
+} from '@material-ui/core';
 
 // Imports for interacting with the db
 import { useMutation, useQuery } from '@apollo/client';
@@ -18,6 +22,9 @@ import { GET_TUTORIAL } from '../utils/queries/tutorialQueries';
 
 // Imports for other utilities
 import { isEmptyInput } from '../utils/validation';
+
+// Component imports
+import { ViewLesson } from '../components/ViewLesson';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -35,6 +42,7 @@ const useStyles = makeStyles((theme) => ({
 
 export function AddLessons() {
   const classes = useStyles();
+  const stylesFromAddLesson = { marginBottom: '1rem' };
 
   // Set default state values
   const inputDefaultValues = {
@@ -110,12 +118,11 @@ export function AddLessons() {
     return (
       <>
         {lessons.map((lesson) => (
-          <div>
-            <p>Name: {lesson.name}</p>
-            <p>Body: {lesson.body}</p>
-            <p>Media: {lesson.media}</p>
-            <p>Duration: {lesson.duration}</p>
-          </div>
+          <ViewLesson 
+            key={lesson._id}
+            lessonFromAddLessons={lesson}
+            stylesFromAddLesson={stylesFromAddLesson}
+          />
         ))}
       </>
     );
@@ -270,13 +277,20 @@ export function AddLessons() {
           Save Lesson
         </Button>
       </Box>
-      <Typography component='h2' variant='h6'>
+      <Divider variant='middle' />
+      <Typography 
+        component='h2' 
+        variant='h5'
+        style={{
+          margin: '2rem 0'
+        }}
+      >
         Lessons in This Tutorial
       </Typography>
       {
-        lessons && lessons.length > 0 ? 
-          <Box>{lessonList(lessons)}</Box> :
-          <p>No lessons yet! Add one above.</p>
+        lessons && lessons.length > 0 ?
+        lessonList(lessons) :
+        <p>No lessons yet! Add one above.</p>
       }
     </div>
   );

--- a/client/src/pages/AddLessons.js
+++ b/client/src/pages/AddLessons.js
@@ -48,15 +48,39 @@ export function AddLessons() {
   const [media, setMedia] = useState(inputDefaultValues);
   const [duration, setDuration] = useState(inputDefaultValues);
 
-  // Set up mutation to add the tutorial to the db
-  const [addLesson, { error: lessonError }] = useMutation(ADD_LESSON);
+  // Set up mutation to add the lesson to the db
+  // Use the cache to add each new lesson to the bottom of the page upon saving
+  const [addLesson, { error: lessonError }] = useMutation(ADD_LESSON, {
+    update(cache, { data: { addLesson } }) {
+      try {
+        const { tutorial } = cache.readQuery({ 
+          query: GET_TUTORIAL, 
+          variables: { tutorialId } 
+        });
+        const { lessons } = tutorial;
+
+        cache.writeQuery({
+          query: GET_TUTORIAL,
+          variables: { tutorialId },
+          data: { 
+            tutorial: {
+              ...tutorial,
+              lessons: [...lessons, addLesson]
+            } 
+          },
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    },
+  });
 
   // Get tutorial ID from URL wildcard
   const { tutorialId } = useParams();
 
   // Set up query to get the tutorial from the db
   const { loading, error, data } = useQuery(GET_TUTORIAL, {
-    variables: { id: tutorialId },
+    variables: { tutorialId },
   });
 
   if (loading) {


### PR DESCRIPTION
On the `/:tutorialId/lessons/add` page, when a user saves a lesson, the lesson should appear at the bottom of the page without having to refresh the page.

Additionally, lessons should be rendering as cards now, the same way they do on the `ViewTutorial` page (same `ViewLesson` component is used).

I had to add some code to the `ViewLesson` component but it is intended to only impact the rendering of the lesson on the `AddLessons` page; the view of a lesson on the `ViewTutorial` page should not be changed and should contain all the correct data (please confirm).

More styling and descriptive text on the page to come.

Closes #132 