### PR TITLE
Render image in lesson only if there is a value for it

### DIFF
--- a/client/src/components/ViewLesson.js
+++ b/client/src/components/ViewLesson.js
@@ -23,10 +23,8 @@ export function ViewLesson({ lessonFromAddLessons, stylesFromAddLesson }) {
   // If lesson was passed from AddLessons use that id to get lesson
   // otherwise use lessonId from useParams()
   const { loading, err, data } = useQuery(GET_LESSON, {
-    variables: { 
-      lessonId: lessonFromAddLessons ? 
-        lessonFromAddLessons._id : 
-        lessonId 
+    variables: {
+      lessonId: lessonFromAddLessons ? lessonFromAddLessons._id : lessonId,
     },
   });
   console.log(loading, err, data);
@@ -47,29 +45,21 @@ export function ViewLesson({ lessonFromAddLessons, stylesFromAddLesson }) {
 
   return (
     <Container style={stylesFromAddLesson}>
-      <Grid
-        container
-        justifyContent='center'
-      >
-        <Grid
-          item
-          xs={10}
-        >
+      <Grid container justifyContent='center'>
+        <Grid item xs={10}>
           <Card>
             <CardActionArea>
-              <CardMedia
-                component='img'
-                alt='User-provided image'
-                height='140'
-                image={media}
-                title='Lesson Media'
-              />
+              {media && (
+                <CardMedia
+                  component='img'
+                  alt='User-provided image'
+                  height='140'
+                  image={media}
+                  title='Lesson Media'
+                />
+              )}
               <CardContent>
-                <Typography
-                  gutterBottom
-                  variant='h5'
-                  component='h2'
-                >
+                <Typography gutterBottom variant='h5' component='h2'>
                   {name}
                 </Typography>
                 <Typography
@@ -80,11 +70,7 @@ export function ViewLesson({ lessonFromAddLessons, stylesFromAddLesson }) {
                 >
                   Time: {duration} minute(s)
                 </Typography>
-                <Typography
-                  variant='body2'
-                  color='textSecondary'
-                  component='p'
-                >
+                <Typography variant='body2' color='textSecondary' component='p'>
                   {body}
                 </Typography>
               </CardContent>


### PR DESCRIPTION
Render the CardMedia component for a lesson image only if the user added an image URL to the field. Previously there was a broken image icon if there was no image; now you should see a card with only the title, body, and duration when there is no image.

To test, you will need to add your own lesson that has no image to a tutorial. You can go directly to the page to add a lesson by grabbing a tutorial ID from Compass and then going to `/:tutorialId/lessons/add`. Upon saving, the lesson card should be at the bottom of the screen.

Notes:
- I discovered a bug where the above method of lesson creation created a new tutorial rather than editing the existing one. I plan to look into that in a future PR.
- I also plan to add a message on successful save of a lesson.

Most of the changes in this PR are from formatting the file with Prettier. The only actual code changes are lines 52-60.

closes #150 