### PR TITLE
Require user to be logged in to visit add tutorial / add lesson

### DIFF
--- a/client/src/pages/AddLessons.js
+++ b/client/src/pages/AddLessons.js
@@ -14,6 +14,7 @@ import { GET_USER } from '../utils/queries/userQueries';
 
 // Imports for other utilities
 import { isEmptyInput, validateInput } from '../utils/validation';
+import auth from '../utils/auth';
 
 // Component imports
 import { ViewLesson } from '../components/ViewLesson';
@@ -35,6 +36,11 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export function AddLessons() {
+  //check login status
+  if (!auth.loggedIn()) {
+    window.location.assign('/signin');
+  }
+
   const classes = useStyles();
   const stylesFromAddLesson = { marginBottom: '1rem' };
   const dividerStyles = { width: '90%', margin: '2rem auto' };
@@ -138,7 +144,7 @@ export function AddLessons() {
     e.preventDefault();
 
     // If user is not logged in or is not the teacher, set state to show error and exit submit function
-    if (!user || user._id !== teacher[0]._id) {
+    if (!auth.loggedIn() || user._id !== teacher[0]._id) {
       setCanSubmit(false);
       return;
     }
@@ -327,8 +333,8 @@ export function AddLessons() {
         />
         {!canSubmit && (
           <Typography color='error' component='p'>
-            You must be signed in as the instructor of this tutorial in order to add a lesson to it.{' '}
-            <Link to='/signin'>Sign In</Link>
+            You must be signed in as the instructor of this tutorial in order to
+            add a lesson to it. <Link to='/signin'>Sign In</Link>
           </Typography>
         )}
         <Button type='submit' variant='contained' sx={{ mt: 3 }}>

--- a/client/src/pages/AddTutorial.js
+++ b/client/src/pages/AddTutorial.js
@@ -23,6 +23,7 @@ import { ADD_TUTORIAL } from '../utils/mutations/tutorialMutations';
 
 // Imports for other utilities
 import { isEmptyInput, validateInput } from '../utils/validation';
+import auth from '../utils/auth';
 
 const useStyles = makeStyles((theme) => ({
   formControl: {
@@ -67,6 +68,11 @@ function getStyles(category, selectedCategories, theme) {
 }
 
 export function AddTutorial() {
+  //check login status
+  if (!auth.loggedIn()) {
+    window.location.assign('/signin');
+  }
+
   const classes = useStyles();
   const theme = useTheme();
 
@@ -106,7 +112,7 @@ export function AddTutorial() {
     e.preventDefault();
 
     // If user is not logged in, set state to show error and exit submit function
-    if (!user) {
+    if (!auth.loggedIn()) {
       setLoggedOut(true);
       return;
     }


### PR DESCRIPTION
Check the user's login status when they try to visit `/tutorials/new` or `/:tutorialId/lessons/add`. If they are not logged in, redirect them to the sign in page.