### PR TITLE
Conditionally render delete button if on add lessons page

### DIFF
--- a/client/src/components/DeleteButton.js
+++ b/client/src/components/DeleteButton.js
@@ -11,96 +11,98 @@ import { DELETE_REVIEW } from '../utils/mutations/reviewMutations';
 //delte button that takes in a case prop to check if the case is user, lesson, tutorial, or comment
 // another prop of id to pass in the id of the case
 export function DeleteButton(props) {
-    //this checks case and switch to the correct mutation
-    const [deleteUser, { error: userError }] = useMutation(REMOVE_USER);
-    const [deleteLesson, { error: lessonError }] = useMutation(DELETE_LESSON);
-    const [deleteTutorial, { error: tutorialError }] = useMutation(DELETE_TUTORIAL);
-    const [deleteReview, { error: reviewError }] = useMutation(DELETE_REVIEW);
-    //set error state
-    const [error, setError] = useState();
+  //this checks case and switch to the correct mutation
+  const [deleteUser, { error: userError }] = useMutation(REMOVE_USER);
+  const [deleteLesson, { error: lessonError }] = useMutation(DELETE_LESSON);
+  const [deleteTutorial, { error: tutorialError }] =
+    useMutation(DELETE_TUTORIAL);
+  const [deleteReview, { error: reviewError }] = useMutation(DELETE_REVIEW);
+  //set error state
+  const [error, setError] = useState();
 
-    const handleDelete = async (e) => {
-        e.preventDefault();
-        console.log(props.case);
-        console.log('at handle delete');
-        switch (props.case) {
-            case 'user':
-                //delete user mutation
-                try {
-                    await deleteUser();
-                    if(userError){
-                        setError('Something went wrong:', userError);
-                        break;
-                    }
-                    window.location.assign('/signin');
-                    window.alert('User deleted');
-                } catch (err) {
-                    setError('Something went wrong:', err);
-                }
-                break;
-            case 'lesson':
-                //delete lesson mutation
-                try {
-                    await deleteLesson({
-                        variables: { _id: props._id }
-                    });
-                    if(lessonError){
-                        setError('Something went wrong:', lessonError);
-                        break;
-                    }
-                    window.alert('Lesson deleted');
-                } catch (err) {
-                    setError('Something went wrong:', err);
-                }
-            case 'tutorial':
-                //delete tutorial mutation
-                try {
-                    await deleteTutorial({
-                        variables: { _id: props._id }
-                    });
-                    if(tutorialError){
-                        setError('Something went wrong:', tutorialError);
-                        break;
-                    }
-                    window.alert('Tutorial deleted');
-                } catch (err) {
-                    setError('Something went wrong:', err);
-                }
-                break;
-            case 'review':
-                //delete comment mutation
-                try {
-                    deleteReview({
-                        variables: { _id: props._id }
-                    });
-                    if(reviewError){
-                        setError('Something went wrong:', reviewError);
-                    }
-                    break;
-                } catch (err) {
-                    setError('Something went wrong:', err);
-                }
-                break;
-            default:
-                setError('Something went wrong:', 'No case was found');
-                break;
+  const handleDelete = async (e) => {
+    e.preventDefault();
+    console.log(props.case);
+    console.log('at handle delete');
+    switch (props.case) {
+      case 'user':
+        //delete user mutation
+        try {
+          await deleteUser();
+          if (userError) {
+            setError('Something went wrong:', userError);
+            break;
+          }
+          window.location.assign('/signin');
+          window.alert('User deleted');
+        } catch (err) {
+          setError('Something went wrong:', err);
         }
-    };
+        break;
+      case 'lesson':
+        //delete lesson mutation
+        try {
+          await deleteLesson({
+            variables: { _id: props._id },
+          });
+          if (lessonError) {
+            setError('Something went wrong:', lessonError);
+            break;
+          }
+          window.alert('Lesson deleted');
+        } catch (err) {
+          setError('Something went wrong:', err);
+        }
+        break;
+      case 'tutorial':
+        //delete tutorial mutation
+        try {
+          await deleteTutorial({
+            variables: { _id: props._id },
+          });
+          if (tutorialError) {
+            setError('Something went wrong:', tutorialError);
+            break;
+          }
+          window.alert('Tutorial deleted');
+        } catch (err) {
+          setError('Something went wrong:', err);
+        }
+        break;
+      case 'review':
+        //delete comment mutation
+        try {
+          deleteReview({
+            variables: { _id: props._id },
+          });
+          if (reviewError) {
+            setError('Something went wrong:', reviewError);
+          }
+          break;
+        } catch (err) {
+          setError('Something went wrong:', err);
+        }
+        break;
+      default:
+        setError('Something went wrong:', 'No case was found');
+        break;
+    }
+  };
 
-    return (
-        <>
-            <Button 
-                onClick={handleDelete} 
-                variant="contained" 
-                type="submit"
-                startIcon={<DeleteIcon />}
-                color="secondary">
-                Delete
-            </Button>
-            {error && <FormHelperText error={true}>{error}</FormHelperText>}
-        </>
-    );
-
+  return (
+    <>
+      <Button
+        onClick={handleDelete}
+        variant='contained'
+        type='submit'
+        startIcon={<DeleteIcon />}
+        color='secondary'
+      >
+        Delete
+      </Button>
+      {error && <FormHelperText error={true}>{error}</FormHelperText>}
+    </>
+  );
 }
 
 export default DeleteButton;

--- a/client/src/components/ViewLesson.js
+++ b/client/src/components/ViewLesson.js
@@ -1,8 +1,10 @@
 import { React } from 'react';
-import { useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router-dom';
+import { DeleteButton } from '../components/DeleteButton';
 
 //Material-UI imports
 import {
+  Box,
   Card,
   CardActionArea,
   CardContent,
@@ -16,7 +18,11 @@ import {
 import { useQuery } from '@apollo/client';
 import { GET_LESSON } from '../utils/queries/lessonQueries';
 
-export function ViewLesson({ lessonFromAddLessons, stylesFromAddLesson }) {
+export function ViewLesson({
+  lessonFromAddLessons,
+  stylesFromAddLesson,
+  onAddLessonsPage,
+}) {
   //get index and ID from URL and get associated lesson data from db
   const { index, lessonId } = useParams();
 
@@ -41,7 +47,7 @@ export function ViewLesson({ lessonFromAddLessons, stylesFromAddLesson }) {
   }
 
   //destructure fields from lesson object
-  const { name, body, media, duration } = lesson;
+  const { name, body, media, duration, _id } = lesson;
 
   return (
     <Container style={stylesFromAddLesson}>
@@ -73,6 +79,11 @@ export function ViewLesson({ lessonFromAddLessons, stylesFromAddLesson }) {
                 <Typography variant='body2' color='textSecondary' component='p'>
                   {body}
                 </Typography>
+                {onAddLessonsPage && (
+                  <Box style={{ marginTop: '1rem' }}>
+                    <DeleteButton case='lesson' _id={_id} />
+                  </Box>
+                )}
               </CardContent>
             </CardActionArea>
           </Card>

--- a/client/src/components/ViewLesson.js
+++ b/client/src/components/ViewLesson.js
@@ -1,5 +1,5 @@
 import { React } from 'react';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { DeleteButton } from '../components/DeleteButton';
 
 //Material-UI imports

--- a/client/src/pages/AddLessons.js
+++ b/client/src/pages/AddLessons.js
@@ -52,6 +52,7 @@ export function AddLessons() {
   const [duration, setDuration] = useState(inputDefaultValues);
   const [success, setSuccess] = useState(false);
   const [canSubmit, setCanSubmit] = useState(true);
+  const [onAddLessonsPage, setOnAddLessonsPage] = useState(true);
 
   // Set up mutation to add the lesson to the db
   // Use the cache to add each new lesson to the bottom of the page upon saving
@@ -127,6 +128,7 @@ export function AddLessons() {
             key={lesson._id}
             lessonFromAddLessons={lesson}
             stylesFromAddLesson={stylesFromAddLesson}
+            onAddLessonsPage={onAddLessonsPage}
           />
         ))}
       </>
@@ -327,8 +329,8 @@ export function AddLessons() {
         />
         {!canSubmit && (
           <Typography color='error' component='p'>
-            You must be signed in as the instructor of this tutorial in order to add a lesson to it.{' '}
-            <Link to='/signin'>Sign In</Link>
+            You must be signed in as the instructor of this tutorial in order to
+            add a lesson to it. <Link to='/signin'>Sign In</Link>
           </Typography>
         )}
         <Button type='submit' variant='contained' sx={{ mt: 3 }}>


### PR DESCRIPTION
This PR adds functionality to delete a lesson from the add lessons page. You will have to go through the steps to create a tutorial and a lesson in order to test it.

Please also view a lesson on the view tutorial page and confirm you do *not* see the delete button there.

Changes to `DeleteButton.js` are mostly from running Prettier. All I changed was adding `break;` to the `lesson` case.

Note that page does not yet automatically remove the lesson from the page without a page refresh.