### PR TITLE
Use cache to remove deleted lesson from page

### DIFF
--- a/client/src/components/DeleteButton.js
+++ b/client/src/components/DeleteButton.js
@@ -1,19 +1,53 @@
 import { Button, FormHelperText } from '@mui/material';
 import DeleteIcon from '@material-ui/icons/Delete';
 import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { useMutation } from '@apollo/client';
 import { REMOVE_USER } from '../utils/mutations/userMutations';
 import { DELETE_LESSON } from '../utils/mutations/lessonMutations';
 import { DELETE_TUTORIAL } from '../utils/mutations/tutorialMutations';
 import { DELETE_REVIEW } from '../utils/mutations/reviewMutations';
+import { GET_TUTORIAL } from '../utils/queries/tutorialQueries';
 
 //delte button that takes in a case prop to check if the case is user, lesson, tutorial, or comment
 // another prop of id to pass in the id of the case
 export function DeleteButton(props) {
+  const { tutorialId } = useParams();
+
   //this checks case and switch to the correct mutation
   const [deleteUser, { error: userError }] = useMutation(REMOVE_USER);
-  const [deleteLesson, { error: lessonError }] = useMutation(DELETE_LESSON);
+
+  // Use the cache to remove deleted lesson from the bottom of the page upon saving
+  const [deleteLesson, { error: lessonError }] = useMutation(DELETE_LESSON, {
+    update(cache, { data: { deleteLesson } }) {
+      try {
+        const { tutorial } = cache.readQuery({
+          query: GET_TUTORIAL,
+          variables: { tutorialId },
+        });
+        const { lessons } = tutorial;
+
+        const updatedLessons = lessons.filter((lesson) => {
+          return lesson._id !== props._id;
+        });
+
+        cache.writeQuery({
+          query: GET_TUTORIAL,
+          variables: { tutorialId },
+          data: {
+            tutorial: {
+              ...tutorial,
+              lessons: updatedLessons,
+            },
+          },
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    },
+  });
+
   const [deleteTutorial, { error: tutorialError }] =
     useMutation(DELETE_TUTORIAL);
   const [deleteReview, { error: reviewError }] = useMutation(DELETE_REVIEW);


### PR DESCRIPTION
Use the cache to remove a deleted lesson from the Add Lessons page immediately without needing to refresh. Note that an alert appears when the lesson is deleted, and the lesson doesn't disappear until the alert is dismissed.