### PR TITLE
Card styles/refactor components

### DIFF
--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    border: '2px solid black',
+    
     backgroundColor: '#92b4d4',
     
   },

--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -12,8 +12,7 @@ import { ArrowBack, ArrowForward } from '@material-ui/icons';
 
 const useStyles = makeStyles((theme) => ({
   card: {
-    
-    margin: theme.spacing(2),
+  
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -114,7 +113,7 @@ export function Carousel() {
   return (
     <Grid container justifyContent='center'  >
       <Grid item xs={12}>
-      <Typography variant='h3' style={{textWeight:'bold', marginTop:'5%'}} >Learnify</Typography>
+      <Typography variant='h3' gutterBottom style={{textWeight:'bold', marginTop:'5%'}} >Learnify</Typography>
       </Grid>
       <Grid item xs={12} md={8} alignItems='center'>
         {items.map(function (item, index) {

--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -2,6 +2,7 @@ import { React, useState, useEffect, useRef } from 'react';
 import {
   Card,
   CardContent,
+  Grid,
   makeStyles,
   Typography,
   useTheme,
@@ -10,30 +11,18 @@ import {
 import { ArrowBack, ArrowForward } from '@material-ui/icons';
 
 const useStyles = makeStyles((theme) => ({
-  carousel: {
-    textAlign: 'center',
-    margin: theme.spacing(2, 0),
-  },
-  carouselContent: {
-    display: 'flex',
-    justifyContent: 'center',
-  },
   card: {
-    width: '800px', // Default width for larger screens
+    
     margin: theme.spacing(2),
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     border: '2px solid black',
     backgroundColor: '#92b4d4',
-    [theme.breakpoints.down('sm')]: {
-      // Change width to 400px for smaller screens
-      width: '400px',
-    },
+    
   },
   cardImage: {
     width: '100%',
-    maxHeight: '300px',
     objectFit: 'cover',
   },
   carouselArrows: {
@@ -81,23 +70,23 @@ export function Carousel() {
   const timerRef = useRef(null); // Create a ref to store the timer
 
   // Define the timer function separately
-  function startTimer() {
-    return setInterval(function () {
-      setActiveIndex((prevIndex) => (prevIndex + 1) % items.length);
-    }, 5000);
-  }
+  // function startTimer() {
+  //   return setInterval(function () {
+  //     setActiveIndex((prevIndex) => (prevIndex + 1) % items.length);
+  //   }, 5000);
+  // }
 
-  useEffect(
-    function () {
-      // Start the initial timer
-      timerRef.current = startTimer();
+  // useEffect(
+  //   function () {
+  //     // Start the initial timer
+  //     timerRef.current = startTimer();
 
-      return function () {
-        clearInterval(timerRef.current);
-      };
-    },
-    [items.length]
-  );
+  //     return function () {
+  //       clearInterval(timerRef.current);
+  //     };
+  //   },
+  //   [items.length]
+  // );
 
   function handlePrev() {
     setActiveIndex((prevIndex) => {
@@ -113,19 +102,21 @@ export function Carousel() {
     });
   }
 
-  useEffect(
-    function () {
-      // Clear and restart the timer every time activeIndex changes
-      clearInterval(timerRef.current);
-      timerRef.current = startTimer();
-    },
-    [activeIndex]
-  );
+  // useEffect(
+  //   function () {
+  //     // Clear and restart the timer every time activeIndex changes
+  //     clearInterval(timerRef.current);
+  //     timerRef.current = startTimer();
+  //   },
+  //   [activeIndex]
+  // );
 
   return (
-    <div className={classes.carousel}>
-      <h1>Learnify</h1>
-      <div className={classes.carouselContent}>
+    <Grid container justifyContent='center'  >
+      <Grid item xs={12}>
+      <Typography variant='h3' style={{textWeight:'bold', marginTop:'5%'}} >Learnify</Typography>
+      </Grid>
+      <Grid item xs={12} md={8} alignItems='center'>
         {items.map(function (item, index) {
           return (
             <div
@@ -155,8 +146,8 @@ export function Carousel() {
             </div>
           );
         })}
-      </div>
-      <div className={classes.carouselArrows}>
+      </Grid>
+      <Grid item xs={12} className={classes.carouselArrows}>
         <IconButton
           className={classes.arrowButton}
           color='primary'
@@ -171,8 +162,8 @@ export function Carousel() {
         >
           <ArrowForward />
         </IconButton>
-      </div>
-    </div>
+      </Grid>
+    </Grid>
   );
 }
 

--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -12,13 +12,11 @@ import { ArrowBack, ArrowForward } from '@material-ui/icons';
 
 const useStyles = makeStyles((theme) => ({
   card: {
-  
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    
+
     backgroundColor: '#92b4d4',
-    
   },
   cardImage: {
     width: '100%',
@@ -111,11 +109,28 @@ export function Carousel() {
   // );
 
   return (
-    <Grid container justifyContent='center'  >
-      <Grid item xs={12}>
-      <Typography variant='h3' gutterBottom style={{textWeight:'bold', marginTop:'5%'}} >Learnify</Typography>
+    <Grid
+      container
+      justifyContent='center'
+    >
+      <Grid
+        item
+        xs={12}
+      >
+        <Typography
+          variant='h3'
+          gutterBottom
+          style={{ textWeight: 'bold', marginTop: '5%' }}
+        >
+          Learnify
+        </Typography>
       </Grid>
-      <Grid item xs={12} md={8} alignItems='center'>
+      <Grid
+        item
+        xs={12}
+        md={8}
+        alignItems='center'
+      >
         {items.map(function (item, index) {
           return (
             <div
@@ -134,10 +149,17 @@ export function Carousel() {
                   className={classes.cardImage}
                 />
                 <CardContent>
-                  <Typography variant='h5' component='h3' gutterBottom>
+                  <Typography
+                    variant='h5'
+                    component='h3'
+                    gutterBottom
+                  >
                     {item.title}
                   </Typography>
-                  <Typography variant='body1' component='p'>
+                  <Typography
+                    variant='body1'
+                    component='p'
+                  >
                     {item.description}
                   </Typography>
                 </CardContent>
@@ -146,7 +168,11 @@ export function Carousel() {
           );
         })}
       </Grid>
-      <Grid item xs={12} className={classes.carouselArrows}>
+      <Grid
+        item
+        xs={12}
+        className={classes.carouselArrows}
+      >
         <IconButton
           className={classes.arrowButton}
           color='primary'

--- a/client/src/components/Categories.js
+++ b/client/src/components/Categories.js
@@ -121,7 +121,7 @@ export function SubCategory({ subCategory }) {
               <Grid
                 item
                 xs={10}
-                md={2}
+                md={3}
                 key={option._id}
               >
                 <Card className={classes.card}>

--- a/client/src/components/Categories.js
+++ b/client/src/components/Categories.js
@@ -25,8 +25,12 @@ const useStyles = makeStyles((theme) => ({
   },
   categoryButtons: {
     '& .category-button': {
-      marginRight: theme.spacing(2),
+      margin: theme.spacing(1),
+      background: '#92b4d4',
+      fontWeight: 'bold',
     },
+    
+    
   },
 }));
 
@@ -143,9 +147,10 @@ export function Categories({ categories }) {
         borderColor='black'
         backgroundColor='white'
         p={2}
+        style={{marginTop:16}}
       >
         <Typography variant='h5' gutterBottom>
-          Find Tutorials Based on Category!
+          Browse Tutorials By Category
         </Typography>
         <Grid container spacing={2}>
           <Grid item xs={12}>

--- a/client/src/components/Categories.js
+++ b/client/src/components/Categories.js
@@ -5,6 +5,7 @@ import {
   Typography,
   Card,
   CardContent,
+  CardMedia,
   Box,
   useTheme,
   makeStyles,
@@ -13,6 +14,7 @@ import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import { QUERY_TUTORIALS_BY_CATEGORY } from '../utils/queries/tutorialQueries';
 import { GET_TUTORIALS } from '../utils/queries/tutorialQueries';
+import { HalfRating } from '../components';
 
 const useStyles = makeStyles((theme) => ({
   customLink: {
@@ -29,10 +31,36 @@ const useStyles = makeStyles((theme) => ({
       background: '#92b4d4',
       fontWeight: 'bold',
     },
-    
-    
+  },
+  
+  card: {
+    backgroundColor: 'var(--main-bg-color) !important',
+    textAlign: 'left',
+    height: '100%',
+ 
+
+  },
+  cardTitle: {
+    fontSize: 'calc(16px + (2 * ((100vw - 600px) / (1200 - 600))))',
+    // backgroundColor: 'var(--main-bg-color)',
+    fontWeight: 'bold',
+    padding:0
+  },
+  // Add the new class definition for the link
+  link: {
+    color: 'black', // Set the link color to black by default
+    textDecoration: 'none', // Remove the default underline
+
+    // Define styles for hover state
+    '&:hover': {
+      color: 'blue', // Set the link color to blue on hover
+      textDecoration: 'underline', // Add underline on hover
+    },
   },
 }));
+
+
+
 
 export function SubCategory({ subCategory }) {
   const [selectedSubCategory, setSelectedSubCategory] = useState(subCategory);
@@ -58,13 +86,6 @@ export function SubCategory({ subCategory }) {
     setSelectedSubCategory(subCategory);
   }, [subCategory]);
 
-  const imgStyle = {
-    width: '90%',
-    height: 'auto',
-    overflow: 'hidden',
-    objectFit: 'cover',
-  };
-
   if (loading || loadingTutorials) {
     return <p>Loading...</p>;
   } else if (error || errorTutorials) {
@@ -72,50 +93,59 @@ export function SubCategory({ subCategory }) {
   } else {
     return (
       <>
-        <Grid item xs={12}>
-          <Card
-            border={3}
-            borderRadius={8}
-            borderColor='black'
-            backgroundColor='gray'
-            p={2}
-          >
+        <Grid
+          item
+          xs={12}
+        >
+          <Card style={{ backgroundColor: '#c5dafa' }}>
             <CardContent>
-              <Typography variant='h6' gutterBottom>
+              <Typography
+                variant='h6'
+                gutterBottom
+              >
                 {selectedSubCategory.category}
               </Typography>
             </CardContent>
           </Card>
         </Grid>
         <br />
-        <Grid item xs={12}>
-          <Grid container spacing={2}>
+        <Grid
+          item
+          xs={12}
+        >
+          <Grid
+            container
+            spacing={2}
+          >
             {tutorials.map((option) => (
-              <Grid item xs={10} sm={6} md={3} key={option._id}>
-                <Card
-                  border={3}
-                  borderRadius={8}
-                  borderColor='black'
-                  backgroundColor='white'
-                  p={2}
-                >
-                  <CardContent>
+              <Grid
+                item
+                xs={10}
+                md={2}
+                key={option._id}
+              >
+                <Card className={classes.card}>
+                  <CardMedia
+                    component='img'
+                    alt={option.title}
+                    image={option.thumbnail}
+                    className={`${classes.img}`}
+                  ></CardMedia>
+                  <CardContent style={{ padding: 0 }}>
                     <Link
                       to={`/tutorial/${option._id}`}
                       key={option._id}
-                      className={classes.customLink}
+                      className={classes.link} // Add the new class here for the link
                     >
-                      <Typography variant='subtitle1'>
+                      <Typography className={classes.cardTitle}>
                         {option.title}
                       </Typography>
                     </Link>
-                    <img
-                      src={option.thumbnail}
-                      alt={option.title}
-                      style={imgStyle}
-                    />
-                    <Typography variant='body2'>{option.overview}</Typography>
+                    <Typography className={classes.cardDescription}>
+                      {option.overview}
+                    </Typography>
                   </CardContent>
+                  <HalfRating rating={option.averageRating} />
                 </Card>
               </Grid>
             ))}
@@ -147,13 +177,22 @@ export function Categories({ categories }) {
         borderColor='black'
         backgroundColor='white'
         p={2}
-        style={{marginTop:16}}
+        style={{ marginTop: 16 }}
       >
-        <Typography variant='h5' gutterBottom>
+        <Typography
+          variant='h5'
+          gutterBottom
+        >
           Browse Tutorials By Category
         </Typography>
-        <Grid container spacing={2}>
-          <Grid item xs={12}>
+        <Grid
+          container
+          spacing={2}
+        >
+          <Grid
+            item
+            xs={12}
+          >
             <div className={classes.categoryButtons}>
               {categories.map((category) => (
                 <Button

--- a/client/src/components/Categories.js
+++ b/client/src/components/Categories.js
@@ -40,9 +40,15 @@ const useStyles = makeStyles((theme) => ({
   },
   cardTitle: {
     fontSize: 'calc(16px + (2 * ((100vw - 600px) / (1200 - 600))))',
-    // backgroundColor: 'var(--main-bg-color)',
     fontWeight: 'bold',
     padding: 0,
+  },
+  img: {
+    height: '9em',
+    border: 'solid 1px #d1d7dc',
+    [theme.breakpoints.down('sm')]: {
+      height: '80%',
+    },
   },
   // Add the new class definition for the link
   link: {
@@ -124,7 +130,7 @@ export function SubCategory({ subCategory }) {
                     component='img'
                     alt={option.title}
                     image={option.thumbnail}
-                    className={`${classes.img}`}
+                    className={classes.img}
                   ></CardMedia>
                   <CardContent style={{ padding: 0 }}>
                     <Link

--- a/client/src/components/Categories.js
+++ b/client/src/components/Categories.js
@@ -32,19 +32,17 @@ const useStyles = makeStyles((theme) => ({
       fontWeight: 'bold',
     },
   },
-  
+
   card: {
     backgroundColor: 'var(--main-bg-color) !important',
     textAlign: 'left',
     height: '100%',
- 
-
   },
   cardTitle: {
     fontSize: 'calc(16px + (2 * ((100vw - 600px) / (1200 - 600))))',
     // backgroundColor: 'var(--main-bg-color)',
     fontWeight: 'bold',
-    padding:0
+    padding: 0,
   },
   // Add the new class definition for the link
   link: {
@@ -58,9 +56,6 @@ const useStyles = makeStyles((theme) => ({
     },
   },
 }));
-
-
-
 
 export function SubCategory({ subCategory }) {
   const [selectedSubCategory, setSelectedSubCategory] = useState(subCategory);

--- a/client/src/components/Categories.js
+++ b/client/src/components/Categories.js
@@ -87,7 +87,7 @@ export function SubCategory({ subCategory }) {
         <Grid item xs={12}>
           <Grid container spacing={2}>
             {tutorials.map((option) => (
-              <Grid item xs={12} sm={6} md={3} key={option._id}>
+              <Grid item xs={10} sm={6} md={3} key={option._id}>
                 <Card
                   border={3}
                   borderRadius={8}

--- a/client/src/components/Categories.js
+++ b/client/src/components/Categories.js
@@ -4,6 +4,7 @@ import {
   Grid,
   Typography,
   Card,
+  CardActionArea,
   CardContent,
   CardMedia,
   Box,
@@ -42,6 +43,9 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 'calc(16px + (2 * ((100vw - 600px) / (1200 - 600))))',
     fontWeight: 'bold',
     padding: 0,
+  },
+  cardDescription: {
+    padding: 2,
   },
   img: {
     height: '9em',
@@ -121,18 +125,19 @@ export function SubCategory({ subCategory }) {
             {tutorials.map((option) => (
               <Grid
                 item
-                xs={10}
+                xs={12}
                 md={3}
                 key={option._id}
               >
                 <Card className={classes.card}>
+                <CardActionArea>
                   <CardMedia
                     component='img'
                     alt={option.title}
                     image={option.thumbnail}
                     className={classes.img}
                   ></CardMedia>
-                  <CardContent style={{ padding: 0 }}>
+                  <CardContent  style={{ padding: 2 }}>
                     <Link
                       to={`/tutorial/${option._id}`}
                       key={option._id}
@@ -143,10 +148,11 @@ export function SubCategory({ subCategory }) {
                       </Typography>
                     </Link>
                     <Typography className={classes.cardDescription}>
-                      {option.overview}
+                      {option.teacher?.[0]?.username ?? 'Deleted user'}
                     </Typography>
                   </CardContent>
                   <HalfRating rating={option.averageRating} />
+                  </CardActionArea>
                 </Card>
               </Grid>
             ))}
@@ -209,7 +215,9 @@ export function Categories({ categories }) {
                 </Button>
               ))}
             </div>
+            <Grid item xs={12}>
             {categorySelected && <SubCategory subCategory={selectedCategory} />}
+          </Grid>
           </Grid>
         </Grid>
       </Box>

--- a/client/src/components/DashboardCard.js
+++ b/client/src/components/DashboardCard.js
@@ -1,5 +1,5 @@
 import { React, useState, useEffect } from 'react';
-import { Link, useNavigate} from 'react-router-dom';
+import {useNavigate} from 'react-router-dom';
 import { makeStyles } from '@material-ui/core';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
@@ -217,13 +217,7 @@ export function DashboardCard(props) {
           className={`${classes.img}`}
         />
         <CardContent className={`${classes.cardContent}`}>
-        <Link
-                      to={`/tutorial/${props._id}`}
-                      key={props._id}
-                      className={classes.customLink}
-                    >
           <p className={`${classes.p}`}>{props.title}</p>
-          </Link>
         </CardContent>
       </div>
       <div>

--- a/client/src/components/DashboardCard.js
+++ b/client/src/components/DashboardCard.js
@@ -1,5 +1,4 @@
 import { React, useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
@@ -92,7 +91,6 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export function DashboardCard(props) {
-  const navigate = useNavigate();
   const classes = useStyles();
 
   const [loggedOut, setLoggedOut] = useState(false);
@@ -123,7 +121,7 @@ export function DashboardCard(props) {
     // If user is not logged in, set state to redirect to the Sign In page
     // otherwise sends User's ID back to fave the favorite tutorial
     if (!user) {
-      navigate('/signin');
+      window.location.assign(`/signin`);
       setLoggedOut(true);
       return;
     } else {
@@ -215,7 +213,7 @@ export function DashboardCard(props) {
         </p>
         <HalfRating rating={props.averageRating} />
         <CardActions className={`${classes.cardContent} ${classes.actionBox}`}>
-          <Button size='small' className={`${classes.learnMoreBtn}`} onClick={() => (navigate(`/tutorial/${props.id}`))}>
+          <Button size='small' className={`${classes.learnMoreBtn}`} onClick={() => (window.location.href = `/tutorial/${props.id}`)}>
             Learn More
           </Button>
 

--- a/client/src/components/DashboardCard.js
+++ b/client/src/components/DashboardCard.js
@@ -1,5 +1,5 @@
 import { React, useState, useEffect } from 'react';
-import {useNavigate} from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';

--- a/client/src/components/DashboardCard.js
+++ b/client/src/components/DashboardCard.js
@@ -131,7 +131,7 @@ export function DashboardCard(props) {
     // If user is not logged in, set state to redirect to the Sign In page
     // otherwise sends User's ID back to fave the favorite tutorial
     if (!user) {
-      window.location.assign(`/signin`);
+      navigate(`/signin`);
       setLoggedOut(true);
       return;
     } else {

--- a/client/src/components/DashboardCard.js
+++ b/client/src/components/DashboardCard.js
@@ -1,5 +1,5 @@
 import { React, useState, useEffect } from 'react';
-import {useNavigate} from 'react-router-dom';
+import { Link, useNavigate} from 'react-router-dom';
 import { makeStyles } from '@material-ui/core';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
@@ -217,7 +217,13 @@ export function DashboardCard(props) {
           className={`${classes.img}`}
         />
         <CardContent className={`${classes.cardContent}`}>
+        <Link
+                      to={`/tutorial/${props._id}`}
+                      key={props._id}
+                      className={classes.customLink}
+                    >
           <p className={`${classes.p}`}>{props.title}</p>
+          </Link>
         </CardContent>
       </div>
       <div>

--- a/client/src/components/DashboardCard.js
+++ b/client/src/components/DashboardCard.js
@@ -1,4 +1,5 @@
 import { React, useState, useEffect } from 'react';
+import {useNavigate} from 'react-router-dom';
 import { makeStyles } from '@material-ui/core';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import FavoriteIcon from '@mui/icons-material/Favorite';
@@ -92,6 +93,7 @@ const useStyles = makeStyles((theme) => ({
 
 export function DashboardCard(props) {
   const classes = useStyles();
+  const navigate = useNavigate();
 
   const [loggedOut, setLoggedOut] = useState(false);
   const [favoriteBorderIcon, setFavoriteBorderIcon] = useState(!props.favorite);

--- a/client/src/components/DashboardCarousel.js
+++ b/client/src/components/DashboardCarousel.js
@@ -74,9 +74,9 @@ export function DashboardCarousel(props) {
     },
   };
 
-  const saved = props.items.filter(item => props.user.favorites.some(
-    (favorite) => favorite._id === item._id
-  ));
+  const saved = props.items.filter((item) =>
+    props.user.favorites.some((favorite) => favorite._id === item._id)
+  );
 
   return (
     <div className={`${classes.container}`}>
@@ -133,7 +133,6 @@ export function DashboardCarousel(props) {
               index
             ) => {
               // Check if user's favorite array includes current tutorial ID
-
 
               return (
                 <DashboardCard

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -1,23 +1,27 @@
 import React from 'react';
 import LearnifyLogo from '../images/learnify-logo__1_-removebg.png';
 import { NavLink } from 'react-router-dom';
+import { Container, Grid, Typography } from '@material-ui/core';
 
 export function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
     <footer
-      style={{ backgroundColor: '#a5aaad', color: 'white', padding: '10px' }}
+      style={{ backgroundColor: '#a5aaad', color: 'white', marginTop:'3%'}}
     >
-      <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Grid container xs={12} alignItems='center'>
+      
+      <Grid item xs={1}>
         <img
           src={LearnifyLogo}
           alt='Company Logo'
-          style={{ width: '80px', marginRight: '10px' }}
+          style={{ width: '80px', marginRight: '2%' }}
         />
-        <p>&copy; {currentYear} Learnify. All rights reserved.</p>
-      </div>
-      <div style={{ marginTop: '10px' }}>
+        </Grid>
+        <Grid item xs={3}>
+        </Grid>        
+      <Grid item xs={4}>
         < NavLink to='/about' style={{ color: 'white', marginRight: '10px' }}>
           About
         </NavLink>
@@ -27,7 +31,9 @@ export function Footer() {
         <NavLink to='/donate' style={{ color: 'white' }}>
           Donate
         </NavLink>
-      </div>
+      </Grid>
+      <Grid item xs={4}></Grid>
+      </Grid>
     </footer>
   );
 }

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -8,7 +8,7 @@ export function Footer() {
 
   return (
     <footer
-      style={{ backgroundColor: '#a5aaad', color: 'white', marginTop:'3%'}}
+      style={{ backgroundColor: '#72767d', color: 'white', marginTop:'3%'}}
     >
       <Grid container xs={12} alignItems='center'>
       

--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -7,7 +7,7 @@ export function Footer() {
 
   return (
     <footer
-      style={{ backgroundColor: 'black', color: 'white', padding: '10px' }}
+      style={{ backgroundColor: '#a5aaad', color: 'white', padding: '10px' }}
     >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <img

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -19,7 +19,7 @@ import Auth from '../utils/auth';
 
 const useStyles = makeStyles((theme) => ({
   appBar: {
-    backgroundColor: '#FAF0E6',
+    backgroundColor: '#c1c5c7',
     color: 'black',
     opacity: '0.7',
     height: '60px',
@@ -117,6 +117,7 @@ export function Navbar() {
         keepMounted
         open={Boolean(anchorEl)}
         onClose={handleCloseMenus}
+        fontSize='large'
       >
         {categories
           .slice()

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme) => ({
     opacity: '0.7',
     height: '60px',
     userSelect: 'none',
+    marginBottom:'3%',
   },
   logo: {
     width: '100px',

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -15,6 +15,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'var(--main-bg-color) !important',
     textAlign: 'left',
     height: '100%',
+    margin: theme.spacing(2)
  
 
   },
@@ -68,15 +69,15 @@ export function Recommended() {
   }
 
   const tutorials = data?.tutorials || [];
-  const visibleTutorials = tutorials.slice(currentIndex, currentIndex + 5);
+  const visibleTutorials = tutorials.slice(currentIndex, currentIndex + 4);
 
   function handlePrev() {
-    setCurrentIndex((prevIndex) => Math.max(prevIndex - 5, 0));
+    setCurrentIndex((prevIndex) => Math.max(prevIndex - 4, 0));
   }
 
   function handleNext() {
     setCurrentIndex((prevIndex) =>
-      Math.min(prevIndex + 5, tutorials.length - 5)
+      Math.min(prevIndex + 4, tutorials.length - 4)
     );
   }
 
@@ -85,7 +86,7 @@ export function Recommended() {
       <Typography variant='h4' gutterBottom>Recommended Tutorials</Typography>
       <Grid container justifyContent='space-around'>
         {visibleTutorials.map((tutorial) => (
-          <Grid item xs={10} md={2}>
+          <Grid item xs={10} md={3}>
           <Card
             key={tutorial._id}
             className={classes.card}

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -1,7 +1,7 @@
 import { React, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import { Card, CardActionArea, CardContent, CardMedia, Container, Grid, Typography, IconButton } from '@material-ui/core';
+import { Card, CardContent, CardMedia, Container, Grid, Typography, IconButton } from '@material-ui/core';
 import { ArrowBack, ArrowForward } from '@material-ui/icons';
 import { useQuery } from '@apollo/client';
 import { GET_TUTORIALS } from '../utils/queries/tutorialQueries';

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -1,7 +1,7 @@
 import { React, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import { Card, CardContent, Typography, IconButton } from '@material-ui/core';
+import { Card, CardActionArea, CardContent, CardMedia, Grid, Typography, IconButton } from '@material-ui/core';
 import { ArrowBack, ArrowForward } from '@material-ui/icons';
 import { useQuery } from '@apollo/client';
 import { GET_TUTORIALS } from '../utils/queries/tutorialQueries';
@@ -21,17 +21,21 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   card: {
+    backgroundColor: 'var(--main-bg-color) !important',
+    textAlign: 'left',
     width: 'calc(25% - 10px)',
-    backgroundColor: '#92b4d4',
-    marginBottom: theme.spacing(2),
-    border: `2px solid ${theme.palette.type === 'black'}`,
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
     [theme.breakpoints.down('sm')]: {
-      width: '100%', // Set the width to 100% on small screens to make cards stack vertically
+      margin: '1em 0',
     },
   },
   cardTitle: {
     fontSize: 18,
     fontWeight: 'bold',
+    alignContent: 'start'
   },
   cardDescription: {
     fontSize: 14,
@@ -46,6 +50,14 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(1),
     color: 'black',
   },
+  img: {
+    height: '9em',
+    border: 'solid 1px #d1d7dc',
+    [theme.breakpoints.down('sm')]: {
+      height: '80%',
+    },
+  },
+
 
   // Add the new class definition for the link
   link: {
@@ -91,7 +103,7 @@ export function Recommended() {
   return (
     <div className={classes.recommendations}>
       <h2>Recommendations For You!</h2>
-      <div className={classes.recommendationsContent}>
+      <Grid container className={classes.recommendationsContent}>
         {visibleTutorials.map((tutorial) => (
           <Card
             key={tutorial._id}
@@ -102,17 +114,20 @@ export function Recommended() {
               }`,
             }}
           >
-            <img
-              src={tutorial.thumbnail}
-              alt={tutorial.title}
-              style={{ width: '100%', height: '200px' }} // Set a fixed height for the images (adjust the height as needed)
-            />
+            <CardMedia
+            component='img'
+            alt={tutorial.title}
+            image={tutorial.thumbnail}
+            className={`${classes.img}`}
+            >
+            </CardMedia>
             <CardContent>
               <Link
                 to={`/tutorial/${tutorial._id}`}
                 key={tutorial._id}
                 className={classes.link} // Add the new class here for the link
               >
+                
                 <Typography className={classes.cardTitle}>
                   {tutorial.title}
                 </Typography>
@@ -123,7 +138,8 @@ export function Recommended() {
             </CardContent>
           </Card>
         ))}
-      </div>
+      </Grid>
+
       {/* Render the arrow buttons only if the screen is full screen */}
       {isFullScreen && (
         <div className={classes.recommendationsArrows}>

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -1,29 +1,20 @@
 import { React, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import { Card, CardActionArea, CardContent, CardMedia, Grid, Typography, IconButton } from '@material-ui/core';
+import { Card, CardActionArea, CardContent, CardMedia, Container, Grid, Typography, IconButton } from '@material-ui/core';
 import { ArrowBack, ArrowForward } from '@material-ui/icons';
 import { useQuery } from '@apollo/client';
 import { GET_TUTORIALS } from '../utils/queries/tutorialQueries';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
+import Carousel from 'react-multi-carousel';
+import 'react-multi-carousel/lib/styles.css';
 
 const useStyles = makeStyles((theme) => ({
-  recommendations: {
-    margin: theme.spacing(2, 0),
-  },
-  recommendationsContent: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    [theme.breakpoints.down('sm')]: {
-      flexDirection: 'column', // Switch to column layout on small screens
-      margin: theme.spacing(0, 1),
-    },
-  },
+
+
   card: {
     backgroundColor: 'var(--main-bg-color) !important',
     textAlign: 'left',
-    width: 'calc(25% - 10px)',
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
@@ -88,23 +79,24 @@ export function Recommended() {
   }
 
   const tutorials = data?.tutorials || [];
-  const visibleTutorials = tutorials.slice(currentIndex, currentIndex + 4);
+  const visibleTutorials = tutorials.slice(currentIndex, currentIndex + 5);
 
   function handlePrev() {
-    setCurrentIndex((prevIndex) => Math.max(prevIndex - 4, 0));
+    setCurrentIndex((prevIndex) => Math.max(prevIndex - 5, 0));
   }
 
   function handleNext() {
     setCurrentIndex((prevIndex) =>
-      Math.min(prevIndex + 4, tutorials.length - 4)
+      Math.min(prevIndex + 5, tutorials.length - 5)
     );
   }
 
   return (
-    <div className={classes.recommendations}>
-      <h2>Recommendations For You!</h2>
-      <Grid container className={classes.recommendationsContent}>
+    <Container maxWidth>
+      <Typography variant='h4' gutterBottom>Recommended Tutorials</Typography>
+      <Grid container justifyContent='space-around'>
         {visibleTutorials.map((tutorial) => (
+          <Grid item xs={10} md={2}>
           <Card
             key={tutorial._id}
             className={classes.card}
@@ -137,8 +129,10 @@ export function Recommended() {
               </Typography>
             </CardContent>
           </Card>
+          </Grid>
         ))}
       </Grid>
+
 
       {/* Render the arrow buttons only if the screen is full screen */}
       {isFullScreen && (
@@ -161,7 +155,7 @@ export function Recommended() {
           </IconButton>
         </div>
       )}
-    </div>
+    </Container >
   );
 }
 

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -16,27 +16,19 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'var(--main-bg-color) !important',
     textAlign: 'left',
     height: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    [theme.breakpoints.down('sm')]: {
-      margin: '1em 0',
-    },
+
   },
   cardTitle: {
-    fontSize: 18,
+    fontSize: 'calc(16px + (2 * ((100vw - 600px) / (1200 - 600))))',
+    // backgroundColor: 'var(--main-bg-color)',
     fontWeight: 'bold',
-    alignContent: 'start'
+    padding:0
   },
   cardDescription: {
     fontSize: 14,
     color: theme.palette.text.secondary,
   },
-  recommendationsArrows: {
-    display: 'flex',
-    justifyContent: 'center',
-    marginTop: theme.spacing(2),
-  },
+
   arrowButton: {
     padding: theme.spacing(1),
     color: 'black',
@@ -92,7 +84,7 @@ export function Recommended() {
   }
 
   return (
-    <Container maxWidth>
+    <Container maxWidth >
       <Typography variant='h4' gutterBottom>Recommended Tutorials</Typography>
       <Grid container justifyContent='space-around'>
         {visibleTutorials.map((tutorial) => (
@@ -101,9 +93,7 @@ export function Recommended() {
             key={tutorial._id}
             className={classes.card}
             style={{
-              border: `2px solid ${
-                theme.palette.type === 'dark' ? 'white' : 'black'
-              }`,
+              
             }}
           >
             <CardMedia
@@ -113,7 +103,7 @@ export function Recommended() {
             className={`${classes.img}`}
             >
             </CardMedia>
-            <CardContent>
+            <CardContent style={{padding:0}}>
               <Link
                 to={`/tutorial/${tutorial._id}`}
                 key={tutorial._id}
@@ -136,7 +126,7 @@ export function Recommended() {
 
       {/* Render the arrow buttons only if the screen is full screen */}
       {isFullScreen && (
-        <div className={classes.recommendationsArrows}>
+        <Grid item xs={12} style={{marginTop:theme.spacing(2)}}>
           <IconButton
             className={classes.arrowButton}
             color='primary'
@@ -153,7 +143,7 @@ export function Recommended() {
           >
             <ArrowForward />
           </IconButton>
-        </div>
+        </Grid>
       )}
     </Container >
   );

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -6,8 +6,7 @@ import { ArrowBack, ArrowForward } from '@material-ui/icons';
 import { useQuery } from '@apollo/client';
 import { GET_TUTORIALS } from '../utils/queries/tutorialQueries';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import Carousel from 'react-multi-carousel';
-import 'react-multi-carousel/lib/styles.css';
+import { HalfRating } from '../components';
 
 const useStyles = makeStyles((theme) => ({
 
@@ -16,6 +15,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'var(--main-bg-color) !important',
     textAlign: 'left',
     height: '100%',
+ 
 
   },
   cardTitle: {
@@ -24,10 +24,7 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 'bold',
     padding:0
   },
-  cardDescription: {
-    fontSize: 14,
-    color: theme.palette.text.secondary,
-  },
+
 
   arrowButton: {
     padding: theme.spacing(1),
@@ -118,6 +115,7 @@ export function Recommended() {
                 {tutorial.overview}
               </Typography>
             </CardContent>
+            <HalfRating rating={tutorial.averageRating} />
           </Card>
           </Grid>
         ))}

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import {
   Card,
+  CardActionArea,
   CardContent,
   CardMedia,
   Container,
@@ -25,18 +26,18 @@ const useStyles = makeStyles((theme) => ({
   },
   cardTitle: {
     fontSize: 'calc(16px + (2 * ((100vw - 600px) / (1200 - 600))))',
-    // backgroundColor: 'var(--main-bg-color)',
     fontWeight: 'bold',
-    padding: 0,
+    padding: 2,
   },
-
+  cardDescription: {
+    padding: 2,
+  },
   arrowButton: {
     padding: theme.spacing(1),
     color: 'black',
   },
   img: {
     height: '9em',
-    border: 'solid 1px #d1d7dc',
     [theme.breakpoints.down('sm')]: {
       height: '80%',
     },
@@ -93,26 +94,27 @@ export function Recommended() {
       </Typography>
       <Grid
         container
-        justifyContent='space-around'
+        spacing={2}
       >
         {visibleTutorials.map((tutorial) => (
+          <>
           <Grid
             item
-            xs={10}
-            md={3}
+            xs={12}
+            md={3} 
           >
             <Card
               key={tutorial._id}
               className={classes.card}
-              style={{}}
             >
+              <CardActionArea>
               <CardMedia
                 component='img'
                 alt={tutorial.title}
                 image={tutorial.thumbnail}
                 className={`${classes.img}`}
               ></CardMedia>
-              <CardContent style={{ padding: 0 }}>
+              <CardContent style={{ padding: 2 }}>
                 <Link
                   to={`/tutorial/${tutorial._id}`}
                   key={tutorial._id}
@@ -123,12 +125,14 @@ export function Recommended() {
                   </Typography>
                 </Link>
                 <Typography className={classes.cardDescription}>
-                  {tutorial.overview}
+                  {tutorial.teacher?.[0]?.username ?? 'Deleted user'}
                 </Typography>
               </CardContent>
               <HalfRating rating={tutorial.averageRating} />
+              </CardActionArea>
             </Card>
           </Grid>
+          </>
         ))}
       </Grid>
 

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -1,7 +1,15 @@
 import { React, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import { Card, CardContent, CardMedia, Container, Grid, Typography, IconButton } from '@material-ui/core';
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Container,
+  Grid,
+  Typography,
+  IconButton,
+} from '@material-ui/core';
 import { ArrowBack, ArrowForward } from '@material-ui/icons';
 import { useQuery } from '@apollo/client';
 import { GET_TUTORIALS } from '../utils/queries/tutorialQueries';
@@ -9,23 +17,18 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { HalfRating } from '../components';
 
 const useStyles = makeStyles((theme) => ({
-
-
   card: {
     backgroundColor: 'var(--main-bg-color) !important',
     textAlign: 'left',
     height: '100%',
-    margin: theme.spacing(2)
- 
-
+    margin: theme.spacing(2),
   },
   cardTitle: {
     fontSize: 'calc(16px + (2 * ((100vw - 600px) / (1200 - 600))))',
     // backgroundColor: 'var(--main-bg-color)',
     fontWeight: 'bold',
-    padding:0
+    padding: 0,
   },
-
 
   arrowButton: {
     padding: theme.spacing(1),
@@ -38,7 +41,6 @@ const useStyles = makeStyles((theme) => ({
       height: '80%',
     },
   },
-
 
   // Add the new class definition for the link
   link: {
@@ -82,50 +84,61 @@ export function Recommended() {
   }
 
   return (
-    <Container maxWidth >
-      <Typography variant='h4' gutterBottom>Recommended Tutorials</Typography>
-      <Grid container justifyContent='space-around'>
+    <Container maxWidth>
+      <Typography
+        variant='h4'
+        gutterBottom
+      >
+        Recommended Tutorials
+      </Typography>
+      <Grid
+        container
+        justifyContent='space-around'
+      >
         {visibleTutorials.map((tutorial) => (
-          <Grid item xs={10} md={3}>
-          <Card
-            key={tutorial._id}
-            className={classes.card}
-            style={{
-              
-            }}
+          <Grid
+            item
+            xs={10}
+            md={3}
           >
-            <CardMedia
-            component='img'
-            alt={tutorial.title}
-            image={tutorial.thumbnail}
-            className={`${classes.img}`}
+            <Card
+              key={tutorial._id}
+              className={classes.card}
+              style={{}}
             >
-            </CardMedia>
-            <CardContent style={{padding:0}}>
-              <Link
-                to={`/tutorial/${tutorial._id}`}
-                key={tutorial._id}
-                className={classes.link} // Add the new class here for the link
-              >
-                
-                <Typography className={classes.cardTitle}>
-                  {tutorial.title}
+              <CardMedia
+                component='img'
+                alt={tutorial.title}
+                image={tutorial.thumbnail}
+                className={`${classes.img}`}
+              ></CardMedia>
+              <CardContent style={{ padding: 0 }}>
+                <Link
+                  to={`/tutorial/${tutorial._id}`}
+                  key={tutorial._id}
+                  className={classes.link} // Add the new class here for the link
+                >
+                  <Typography className={classes.cardTitle}>
+                    {tutorial.title}
+                  </Typography>
+                </Link>
+                <Typography className={classes.cardDescription}>
+                  {tutorial.overview}
                 </Typography>
-              </Link>
-              <Typography className={classes.cardDescription}>
-                {tutorial.overview}
-              </Typography>
-            </CardContent>
-            <HalfRating rating={tutorial.averageRating} />
-          </Card>
+              </CardContent>
+              <HalfRating rating={tutorial.averageRating} />
+            </Card>
           </Grid>
         ))}
       </Grid>
 
-
       {/* Render the arrow buttons only if the screen is full screen */}
       {isFullScreen && (
-        <Grid item xs={12} style={{marginTop:theme.spacing(2)}}>
+        <Grid
+          item
+          xs={12}
+          style={{ marginTop: theme.spacing(2) }}
+        >
           <IconButton
             className={classes.arrowButton}
             color='primary'
@@ -144,7 +157,7 @@ export function Recommended() {
           </IconButton>
         </Grid>
       )}
-    </Container >
+    </Container>
   );
 }
 

--- a/client/src/components/Recommended.js
+++ b/client/src/components/Recommended.js
@@ -19,7 +19,6 @@ import { HalfRating } from '../components';
 
 const useStyles = makeStyles((theme) => ({
   card: {
-    backgroundColor: 'var(--main-bg-color) !important',
     textAlign: 'left',
     height: '100%',
     margin: theme.spacing(2),

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -7,18 +7,20 @@ import {
 import { useQuery } from '@apollo/client';
 import { GET_CATEGORIES } from '../utils/queries/categoryQueries';
 
+import { Container } from '@material-ui/core';
+
 export function Home() {
 
   const { loading, error, data } = useQuery(GET_CATEGORIES);
 
   return (
-    <div>
+    <Container>
       <Carousel />
       <Recommended />
       { loading 
         ? <p>Loading...</p> 
         : <Categories categories={data.categories} /> }
-    </div>
+    </Container>
   );
 }
 

--- a/client/src/pages/ViewTutorial.js
+++ b/client/src/pages/ViewTutorial.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 
 //import Learnify components
-import { CommentForm, RateTutorial, ViewLesson } from '../components';
+import { CommentForm, RateTutorial, ViewLesson, HalfRating  } from '../components';
 
 //Material-UI imports
 import clsx from 'clsx';
@@ -184,14 +184,7 @@ export function ViewTutorial() {
   //get number of reviews
   let totalReviews = reviews.length;
   console.log(reviews.length);
-  //calculate average rating
-  let totalRating = 0;
-  for (const review of reviews) {
-    totalRating += review.rating;
-  }
-  const averageRating = reviews.length > 0 ? totalRating / reviews.length : 0;
-  console.log(averageRating);
-
+  
   return (
     <div className='root'>
       <Container>
@@ -239,7 +232,7 @@ export function ViewTutorial() {
           </Grid>
           <Divider orientation='vertical' flexItem />
           <Grid item xs={3}>
-            <Rating name='read-only' value={averageRating} readOnly />
+          <HalfRating rating={tutorial.averageRating} />
             <Typography variant='subtitle1'>
               {reviews.length} Ratings
             </Typography>

--- a/client/src/pages/ViewTutorial.js
+++ b/client/src/pages/ViewTutorial.js
@@ -3,7 +3,12 @@ import { Link } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 
 //import Learnify components
-import { CommentForm, RateTutorial, ViewLesson, HalfRating  } from '../components';
+import {
+  CommentForm,
+  RateTutorial,
+  ViewLesson,
+  HalfRating,
+} from '../components';
 
 //Material-UI imports
 import clsx from 'clsx';
@@ -168,11 +173,21 @@ export function ViewTutorial() {
             style={{ backgroundColor: '#dae9f7', margin: 2 }}
           >
             <Grid container>
-              <Grid item xs={4}>
-                <Rating name='read-only' value={review.rating} readOnly />
+              <Grid
+                item
+                xs={4}
+              >
+                <Rating
+                  name='read-only'
+                  value={review.rating}
+                  readOnly
+                />
                 <p>{review.reviewer}</p>
               </Grid>
-              <Grid item xs={8}>
+              <Grid
+                item
+                xs={8}
+              >
                 <p>{review.comment}</p>
               </Grid>
             </Grid>
@@ -184,7 +199,7 @@ export function ViewTutorial() {
   //get number of reviews
   let totalReviews = reviews.length;
   console.log(reviews.length);
-  
+
   return (
     <div className='root'>
       <Container>
@@ -224,15 +239,27 @@ export function ViewTutorial() {
               {username}
             </Typography>
           </Grid>
-          <Divider orientation='vertical' flexItem />
-          <Grid item xs={3}>
+          <Divider
+            orientation='vertical'
+            flexItem
+          />
+          <Grid
+            item
+            xs={3}
+          >
             <Typography variant='h6'>
               Time to complete: {duration} minutes
             </Typography>
           </Grid>
-          <Divider orientation='vertical' flexItem />
-          <Grid item xs={3}>
-          <HalfRating rating={tutorial.averageRating} />
+          <Divider
+            orientation='vertical'
+            flexItem
+          />
+          <Grid
+            item
+            xs={3}
+          >
+            <HalfRating rating={tutorial.averageRating} />
             <Typography variant='subtitle1'>
               {reviews.length} Ratings
             </Typography>
@@ -256,7 +283,10 @@ export function ViewTutorial() {
             marginTop: '2%',
           }}
         >
-          <Grid item xs={5}>
+          <Grid
+            item
+            xs={5}
+          >
             <Card
               style={{
                 backgroundColor: '#dae9f7',
@@ -270,13 +300,21 @@ export function ViewTutorial() {
               />
             </Card>
           </Grid>
-          <Grid item container direction='column' xs={5}>
+          <Grid
+            item
+            container
+            direction='column'
+            xs={5}
+          >
             <Typography variant='body1'>{overview}</Typography>
 
             <CommentForm />
           </Grid>
 
-          <Grid item xs={10}>
+          <Grid
+            item
+            xs={10}
+          >
             <Card style={{ backgroundColor: '#92b4d4', padding: 5 }}>
               {reviewList(reviews)}
             </Card>
@@ -297,7 +335,10 @@ export function ViewTutorial() {
             marginTop: '2%',
           }}
         >
-          <Grid item xs={12}>
+          <Grid
+            item
+            xs={12}
+          >
             <Card
               style={{
                 backgroundColor: '#dae9f7',
@@ -305,7 +346,10 @@ export function ViewTutorial() {
               }}
             >
               <CardContent>
-                <Typography variant='h5' component='h2'>
+                <Typography
+                  variant='h5'
+                  component='h2'
+                >
                   This tutorial has {totalLessons} lessons:
                   <IconButton
                     className={clsx(classes.expand, {
@@ -318,7 +362,11 @@ export function ViewTutorial() {
                     <ExpandMore />
                   </IconButton>
                 </Typography>
-                <Collapse in={expanded} timeout='auto' unmountOnExit>
+                <Collapse
+                  in={expanded}
+                  timeout='auto'
+                  unmountOnExit
+                >
                   <CardContent>{lessonList(lessons)}</CardContent>
                 </Collapse>
               </CardContent>
@@ -362,7 +410,10 @@ export function ViewTutorial() {
               </Button>
             </Grid>
            */}
-            <Grid item xs={10}>
+            <Grid
+              item
+              xs={10}
+            >
               <ViewLesson />
             </Grid>
           </Grid>


### PR DESCRIPTION
This PR makes the styling of the various card components more consistent. It also updates the footer to be more consistent with the rest of the color scheme.  Much of the refactoring was to use Material-UI components rather than divs to take advantage of their built-in styling and reduce the use of 'makeStyles' to simplify the code.

The navigation for the dashboard cards was fixed after a merge conflict resulted in a new error. Imports for `react-router-dom` and `navigate` was defined to fix the link.

I ran prettier on the files, but did not put the imports in alphabetical order.

